### PR TITLE
bug fix: default values in get_manta_sv

### DIFF
--- a/R/get_manta_sv.R
+++ b/R/get_manta_sv.R
@@ -49,8 +49,8 @@
 #' #get the SVs in a region around MYC
 #' myc_locus_sv = get_manta_sv(region = "8:128723128-128774067")
 #'
-get_manta_sv = function(these_sample_ids,
-                        these_samples_metadata,
+get_manta_sv = function(these_sample_ids = NULL,
+                        these_samples_metadata = NULL,
                         projection = "grch37",
                         chromosome,
                         qstart,

--- a/man/get_manta_sv.Rd
+++ b/man/get_manta_sv.Rd
@@ -5,8 +5,8 @@
 \title{Get Manta SVs}
 \usage{
 get_manta_sv(
-  these_sample_ids,
-  these_samples_metadata,
+  these_sample_ids = NULL,
+  these_samples_metadata = NULL,
   projection = "grch37",
   chromosome,
   qstart,

--- a/man/review_hotspots.Rd
+++ b/man/review_hotspots.Rd
@@ -6,7 +6,8 @@
 \usage{
 review_hotspots(
   annotated_maf,
-  genes_of_interest = c("FOXO1", "MYD88", "CREBBP", "NOTCH1", "NOTCH2", "CD79B", "EZH2"),
+  genes_of_interest = c("FOXO1", "MYD88", "CREBBP", "NOTCH1", "NOTCH2", "CD79B",
+    "EZH2"),
   genome_build = "grch37"
 )
 }


### PR DESCRIPTION
There was a discrepancy in how get_manta_sv() worked when no metadata was provided since the approach in id_ease has changed. This small PR resolves the issue.