### PR TITLE
Vsouza hotfixes

### DIFF
--- a/R/get_sample_wildcards.R
+++ b/R/get_sample_wildcards.R
@@ -26,18 +26,18 @@ get_sample_wildcards = function(this_sample_id,
   
   if(sample_meta$pairing_status=="matched"){
     normal_meta = get_gambl_metadata(seq_type_filter = this_seq_type,
-                                     tissue_status_filter = c("normal","tumour")) %>%
+                                     tissue_status_filter = "normal") %>%
       dplyr::filter(patient_id==this_patient_id) %>% 
       dplyr::filter(tissue_status=="normal")
     
-      normal_id = normal_meta$sample_id
-      
-      return(list(tumour_sample_id=this_sample_id,
-               normal_sample_id=normal_id,
-               seq_type = this_seq_type,
-               pairing_status=sample_meta$pairing_status,
-               genome_build=sample_meta$genome_build,
-               unix_group=sample_meta$unix_group))
+    normal_id = normal_meta$sample_id
+    
+    return(list(tumour_sample_id=this_sample_id,
+             normal_sample_id=normal_id,
+             seq_type = this_seq_type,
+             pairing_status=sample_meta$pairing_status,
+             genome_build=sample_meta$genome_build,
+             unix_group=sample_meta$unix_group))
   }else{
     message("This function only works with matched samples for now")
     return()

--- a/man/annotate_hotspots.Rd
+++ b/man/annotate_hotspots.Rd
@@ -36,7 +36,7 @@ Lastly, \code{p_thresh} sets the p value threshold, default is 0.05.
 my_metadata = get_gambl_metadata()
 all_coding_ssm = get_coding_ssm(these_samples_metadata = my_metadata,
                                 projection = "grch37",
-                                seq_type = "genome")
+                                this_seq_type = "genome")
 
 hot_ssms = annotate_hotspots(all_coding_ssm)
 


### PR DESCRIPTION
`get_sample_wildcards` was internally using `get_gambl_metadata` with a multivalue `tissue_status_filter = c("normal", "tumour")`, which is an old setup not supported anymore. Checking `get_sample_wildcards` code, I understand that `tissue_status_filter = "normal"` is what the function needs. Please, someone confirm this. Other changes are only indexation. 