### PR TITLE
Fixing internal calls of get_sample_cn_segments

### DIFF
--- a/R/assign_cn_to_ssm.R
+++ b/R/assign_cn_to_ssm.R
@@ -161,7 +161,7 @@ assign_cn_to_ssm = function(this_sample_id,
     data.table::setkey(seg_sample, Chromosome, Start_Position, End_Position)
     a = data.table::as.data.table(maf_sample)
   }else{
-    seg_sample = get_sample_cn_segments(this_sample_id = this_sample_id, this_seq_type = this_seq_type) %>%
+    seg_sample = get_sample_cn_segments(these_sample_ids = this_sample_id, this_seq_type = this_seq_type) %>%
       dplyr::mutate(size = end - start) %>%
       dplyr::filter(size > 100) %>%
       dplyr::mutate(chrom = gsub("chr", "", chrom)) %>%

--- a/R/collate_pga.R
+++ b/R/collate_pga.R
@@ -43,8 +43,7 @@ collate_pga <- function(
 
     # Get the CN segments
     multi_sample_seg <- get_sample_cn_segments(
-        sample_list = these_samples_metadata$sample_id,
-        multiple_samples = TRUE,
+        these_samples_metadata = these_samples_metadata,
         this_seq_type = this_seq_type
     ) %>%
     dplyr::rename("sample" = "ID")


### PR DESCRIPTION
This PR resolves errors related to internal calls of `get_sample_cn_segments`, calling this function with now deprecated parameters. Affected functions are `assign_cn_to_ssm` and `collate_pga`.