### PR TITLE
Add parameters to get_ssm_by_region(s)

### DIFF
--- a/R/get_ssm_by_region.R
+++ b/R/get_ssm_by_region.R
@@ -13,6 +13,8 @@
 #' @param qstart Query start coordinate of the range you are restricting to.
 #' @param qend Query end coordinate of the range you are restricting to.
 #' @param region Region formatted like chrX:1234-5678 instead of specifying chromosome, start and end separately.
+#' @param these_sample_ids Optional, a vector of multiple sample_id (or a single sample ID as a string) that you want results for.
+#' @param these_samples_metadata Optional, a metadata table (with sample IDs in a column) to subset the return to.
 #' @param basic_columns Set to FALSE to return MAF with all columns (116). Default is TRUE, which returns the first 45 columns. Note that if streamlined is set to TRUE, only two columns will be returned, regardless of what's specified in this parameter.
 #' @param streamlined Return Start_Position and Tumor_Smaple_Barcode as the only two MAF columns. Default is FALSE. Setting to TRUE will overwrite anything specified with `basic_columns`.
 #' @param maf_data An already loaded MAF like object to subset to regions of interest.
@@ -47,6 +49,8 @@ get_ssm_by_region = function(chromosome,
                              qstart,
                              qend,
                              region = "",
+                             these_sample_ids = NULL,
+                             these_samples_metadata = NULL,
                              basic_columns = TRUE,
                              streamlined = FALSE,
                              maf_data,
@@ -57,6 +61,13 @@ get_ssm_by_region = function(chromosome,
                              min_read_support = 3,
                              mode = "slms-3",
                              verbose = FALSE){
+  
+  # get sample ids according with the metadata
+  sample_ids = id_ease(these_samples_metadata = these_samples_metadata,
+                       these_sample_ids = these_sample_ids,
+                       verbose = verbose,
+                       this_seq_type = this_seq_type) %>% 
+    pull(sample_id)
   
   #duplicate the seq type variable used for glue
   seq_type = this_seq_type
@@ -262,6 +273,9 @@ get_ssm_by_region = function(chromosome,
     muts_region = dplyr::filter(maf_data, Chromosome == chromosome & Start_Position > qstart & Start_Position < qend)
     muts_region = dplyr::filter(maf_data, Chromosome == chromosome & Start_Position > qstart & Start_Position < qend)
   }
+  
+  # subset sample ids
+  muts_region = dplyr::filter(muts_region, Tumor_Sample_Barcode %in% sample_ids)
 
   if(streamlined){
     muts_region = muts_region %>%

--- a/R/get_ssm_by_regions.R
+++ b/R/get_ssm_by_regions.R
@@ -10,6 +10,8 @@
 #'
 #' @param regions_list Either provide a vector of regions in the chr:start-end format OR.
 #' @param regions_bed Better yet, provide a bed file with the coordinates you want to retrieve.
+#' @param these_sample_ids Optional, a vector of multiple sample_id (or a single sample ID as a string) that you want results for.
+#' @param these_samples_metadata Optional, a metadata table (with sample IDs in a column) to subset the return to.
 #' @param streamlined If TRUE (default), only 3 columns will be kept in the maf (start, sample_id and region name). 
 #' To return more columns, set this parameter to FALSE, see `basic_column` for more info. 
 #' Note, if this parameter is TRUE, the function will disregard anything specified with `basic_columns`.
@@ -24,6 +26,7 @@
 #' @param basic_columns Parameter to be used when streamlined is FALSE. 
 #' Set this parameter to TRUE for returning a maf with standard 45 columns, set to FALSE to keep all 116 maf columns in the returned object. 
 #' To return all 116 maf columns, set this parameter to FALSE.
+#' @param verbose Boolean parameter set to FALSE per default.
 #'
 #' @return Returns a data frame of variants in MAF-like format.
 #'
@@ -31,16 +34,17 @@
 #' @export
 #'
 #' @examples
-#' #basic usage, adding custom names from bundled ashm data frame
-#' regions_bed = dplyr::mutate(GAMBLR.data::grch37_ashm_regions, name = paste(gene, region, sep = "_"))
+#' regions_bed = GAMBLR.data::grch37_ashm_regions
 #'
 #' ashm_basic_details = get_ssm_by_regions(regions_bed = regions_bed)
 #'
-#' full_details_maf = get_ssm_by_regions(regions_bed = regions_bed,
-#'                                       basic_columns=T)
+#' full_details_maf = get_ssm_by_regions(regions_bed = regions_bed, 
+#'                                       streamlined = FALSE, basic_columns=TRUE)
 #'
 get_ssm_by_regions = function(regions_list,
                               regions_bed,
+                              these_sample_ids = NULL,
+                              these_samples_metadata = NULL,
                               streamlined = TRUE,
                               maf_data = maf_data,
                               use_name_column = FALSE,
@@ -50,7 +54,8 @@ get_ssm_by_regions = function(regions_list,
                               this_seq_type = "genome",
                               projection = "grch37",
                               min_read_support = 4,
-                              basic_columns = FALSE){
+                              basic_columns = FALSE,
+                              verbose = FALSE){
   
   if(streamlined){
     message("Streamlined is set to TRUE, this function will disregard anything specified with basic_columns")
@@ -75,20 +80,22 @@ get_ssm_by_regions = function(regions_list,
   if(missing(maf_data)){
     
     region_mafs = lapply(regions, function(x){get_ssm_by_region(region = x,
+                                                                these_sample_ids = these_sample_ids,
+                                                                these_samples_metadata = these_samples_metadata,
                                                                 streamlined = streamlined,
                                                                 from_indexed_flatfile = from_indexed_flatfile,
                                                                 mode = mode,
                                                                 augmented = augmented,
                                                                 this_seq_type = this_seq_type,
                                                                 projection = projection,
-                                                                basic_columns=basic_columns)})
+                                                                basic_columns = basic_columns)})
   }else{
     region_mafs = lapply(regions, function(x){get_ssm_by_region(region = x,
                                                                 streamlined = streamlined,
                                                                 maf_data = maf_data,
                                                                 from_indexed_flatfile = from_indexed_flatfile,
                                                                 mode = mode,
-                                                                basic_columns=basic_columns)})
+                                                                basic_columns = basic_columns)})
   }
   if(!use_name_column){
     rn = regions

--- a/man/get_ssm_by_region.Rd
+++ b/man/get_ssm_by_region.Rd
@@ -9,6 +9,8 @@ get_ssm_by_region(
   qstart,
   qend,
   region = "",
+  these_sample_ids = NULL,
+  these_samples_metadata = NULL,
   basic_columns = TRUE,
   streamlined = FALSE,
   maf_data,
@@ -29,6 +31,10 @@ get_ssm_by_region(
 \item{qend}{Query end coordinate of the range you are restricting to.}
 
 \item{region}{Region formatted like chrX:1234-5678 instead of specifying chromosome, start and end separately.}
+
+\item{these_sample_ids}{Optional, a vector of multiple sample_id (or a single sample ID as a string) that you want results for.}
+
+\item{these_samples_metadata}{Optional, a metadata table (with sample IDs in a column) to subset the return to.}
 
 \item{basic_columns}{Set to FALSE to return MAF with all columns (116). Default is TRUE, which returns the first 45 columns. Note that if streamlined is set to TRUE, only two columns will be returned, regardless of what's specified in this parameter.}
 

--- a/man/get_ssm_by_regions.Rd
+++ b/man/get_ssm_by_regions.Rd
@@ -7,6 +7,8 @@
 get_ssm_by_regions(
   regions_list,
   regions_bed,
+  these_sample_ids = NULL,
+  these_samples_metadata = NULL,
   streamlined = TRUE,
   maf_data = maf_data,
   use_name_column = FALSE,
@@ -16,13 +18,18 @@ get_ssm_by_regions(
   this_seq_type = "genome",
   projection = "grch37",
   min_read_support = 4,
-  basic_columns = FALSE
+  basic_columns = FALSE,
+  verbose = FALSE
 )
 }
 \arguments{
 \item{regions_list}{Either provide a vector of regions in the chr:start-end format OR.}
 
 \item{regions_bed}{Better yet, provide a bed file with the coordinates you want to retrieve.}
+
+\item{these_sample_ids}{Optional, a vector of multiple sample_id (or a single sample ID as a string) that you want results for.}
+
+\item{these_samples_metadata}{Optional, a metadata table (with sample IDs in a column) to subset the return to.}
 
 \item{streamlined}{If TRUE (default), only 3 columns will be kept in the maf (start, sample_id and region name).
 To return more columns, set this parameter to FALSE, see \code{basic_column} for more info.
@@ -47,6 +54,8 @@ Note, if this parameter is TRUE, the function will disregard anything specified 
 \item{basic_columns}{Parameter to be used when streamlined is FALSE.
 Set this parameter to TRUE for returning a maf with standard 45 columns, set to FALSE to keep all 116 maf columns in the returned object.
 To return all 116 maf columns, set this parameter to FALSE.}
+
+\item{verbose}{Boolean parameter set to FALSE per default.}
 }
 \value{
 Returns a data frame of variants in MAF-like format.
@@ -62,12 +71,11 @@ Is this function not what you are looking for? Try one of the following, similar
 \link{get_ssm_by_samples}, \link{get_ssm_by_region}
 }
 \examples{
-#basic usage, adding custom names from bundled ashm data frame
-regions_bed = dplyr::mutate(GAMBLR.data::grch37_ashm_regions, name = paste(gene, region, sep = "_"))
+regions_bed = GAMBLR.data::grch37_ashm_regions
 
 ashm_basic_details = get_ssm_by_regions(regions_bed = regions_bed)
 
-full_details_maf = get_ssm_by_regions(regions_bed = regions_bed,
-                                      basic_columns=T)
+full_details_maf = get_ssm_by_regions(regions_bed = regions_bed, 
+                                      streamlined = FALSE, basic_columns=TRUE)
 
 }


### PR DESCRIPTION
This PR addresses [this](https://github.com/morinlab/GAMBLR.results/issues/52) issue.

`get_ssm_by_regions` behaviour is the same as before this PR. Bellow, I compare the output of `get_ssm_by_regions` before (`maf_old_version`) and after (`maf_new_version`) this PR.
```
### get maf tables
devtools::load_all("~/repos/gamblr_repos/GAMBLR.results")
maf_new_version = get_ssm_by_regions(regions_bed = GAMBLR.data::grch37_ashm_regions, 
                                     streamlined = F, basic_columns = T)

library(GAMBLR.results)
maf_old_version = get_ssm_by_regions(regions_bed = GAMBLR.data::grch37_ashm_regions, 
                                     streamlined = F, basic_columns = T)

> maf_new_version_na <- maf_new_version %>% replace(is.na(.), "NA")
> maf_old_version_na <- maf_old_version %>% replace(is.na(.), "NA")
> table(maf_new_version_na == maf_old_version_na)

   TRUE 
4636260 

```