### PR TITLE
Fix id_ease when metadata and seq_type are provided

### DIFF
--- a/R/id_ease.R
+++ b/R/id_ease.R
@@ -7,7 +7,7 @@
 #'
 #' @details This function can take sample IDs as a vector of characters, or a metadata table in data frame format.
 #' If no sample IDs are provided to the function, the function will operate on all gambl sample IDs available for the given seq type.
-#' It is highly recommended to run this function with `verbose = TRUE` (default). 
+#' It is highly recommended to run this function with `verbose = TRUE`. 
 #' Since this will not only improve the overall logic on how the function operates.
 #' But also might help with debugging functions that are internally calling this function.
 #' The function also performs sanity checks and notifies the user if any of the requested sample IDs are not found in the metadata.
@@ -54,9 +54,29 @@ id_ease = function(these_samples_metadata = NULL,
     metadata = get_gambl_metadata(seq_type_filter = this_seq_type)
   }else{
     if(verbose){
-      message("id_ease: Metadata is provided...") 
+      message("id_ease: Metadata is provided and samples of the selected seq type are kept...") 
     }
-    metadata = these_samples_metadata
+    metadata = dplyr::filter(these_samples_metadata, seq_type %in% this_seq_type)
+    not_seq_type = setdiff(these_samples_metadata$sample_id, metadata$sample_id)
+    if(length(not_seq_type) > 0){
+      not_seq_type_msg = gettextf("id_ease: WARNING! %i samples in the provided metadata were removed because their seq types are not the same as in the `set_type` argument.",
+                                  length(not_seq_type))
+      if(verbose){
+        max_to_show <- 100
+        if( length(not_seq_type) > max_to_show ){
+          not_seq_type_msg = gettextf("%s Their first %i IDs are:", not_seq_type_msg, 
+                                      max_to_show)
+          not_seq_type = head(not_seq_type, max_to_show)
+        }else{
+          not_seq_type_msg = gettextf("%s Their IDs are:", not_seq_type_msg)
+        }
+        message(not_seq_type_msg)
+        print(not_seq_type)
+      }else{
+        not_seq_type_msg = gettextf("%s Use `verbose = TRUE` to see their IDs.", not_seq_type_msg)
+        message(not_seq_type_msg)
+      }
+    }
   }
   
   #ensure metadata is subset to specified sample IDs


### PR DESCRIPTION
This is the `.results` version of the same fix in `.data` ([this PR](https://github.com/morinlab/GAMBLR.data/pull/69)).

```
> my_meta = get_gambl_metadata() %>% 
+   filter(pathology %in% c("BL", "DLBCL", "FL"))


#### using verbose = FALSE
> meta2 = id_ease(these_samples_metadata = my_meta,
+                 these_sample_ids = NULL,
+                 verbose = FALSE,
+                 this_seq_type = "capture")
id_ease: WARNING! 1288 samples in the provided metadata were removed because their seq types are not the same as in the `set_type` argument. Use `verbose = TRUE` to see their IDs.


#### using verbose = TRUE
> meta2 = id_ease(these_samples_metadata = my_meta,
+                 these_sample_ids = NULL,
+                 verbose = TRUE,
+                 this_seq_type = "capture")
id_ease: Metadata is provided and samples of the selected seq type are kept...
id_ease: WARNING! 1288 samples in the provided metadata were removed because their seq types are not the same as in the `set_type` argument. Their first 100 IDs are:

# the first 100 sample ids are shown. 

id_ease: No sample IDs provided, all sample IDs in the metadata will be kept...
id_ease: Returning metadata for 0 samples...
```