### PR TITLE
Change how `get_gene_expression` handle duplications

### DIFF
--- a/R/calc_mutation_frequency_bin_region.R
+++ b/R/calc_mutation_frequency_bin_region.R
@@ -32,7 +32,7 @@
 #' @export
 #'
 #' @examples
-#' chr11_mut_freq = calc_mutation_frequency_bin_region(region = "chr11:69455000-69459900",
+#' chr11_mut_freq = calc_mutation_frequency_bin_region(region = "11:69455000-69459900",
 #'                                                          slide_by = 10,
 #'                                                          window_size = 10000)
 #'

--- a/R/calc_mutation_frequency_bin_region.R
+++ b/R/calc_mutation_frequency_bin_region.R
@@ -133,7 +133,7 @@ calc_mutation_frequency_bin_region <- function(region,
     message("Using GAMBLR.results::get_ssm_by_region...")
     region_ssm <- list()
     for (st in unique(metadata$seq_type)) {
-      this_seq_type <- GAMBLR.results::get_ssm_by_region(
+      this_seq_type <- GAMBLR.results:::get_ssm_by_region(
         region = region,
         projection = projection,
         streamlined = FALSE,

--- a/R/get_gene_expression.R
+++ b/R/get_gene_expression.R
@@ -205,7 +205,7 @@ get_gene_expression = function(these_samples_metadata,
       } else if(engine == "grep"){
         message("Will read the data using grep")
         #lazily filter on the fly to conserve RAM (use grep without regex)
-        grep_cmd <- paste(gene_ids, collapse = " -e ") %>% 
+        grep_cmd = paste(gene_ids, collapse = " -e ") %>% 
           gettextf("grep -w -F -e %s -e %s %s", gene_id_type, ., tidy_expression_file)
         print(grep_cmd)
         wide_expression_data = fread(cmd = grep_cmd)
@@ -293,6 +293,12 @@ get_gene_expression = function(these_samples_metadata,
           c(multi_exp_split) %>% 
           bind_rows %>% 
           arrange(sample_id, biopsy_id, patient_id, seq_type)
+      }
+      
+      # print warning message if duplications remain
+      if( any(expression_wider$multi_exp == 1) ){
+        k = gettextf("There are %i rows marked as duplicates (`multi_exp` column as 1). Set adequate row prioritization (`default_priority` or `prioritize_rows_by` parameter) to handle them.", sum(expression_wider$multi_exp))
+        warning(k)
       }
       
     }else if(join_with == "mrna"){

--- a/man/calc_mutation_frequency_bin_region.Rd
+++ b/man/calc_mutation_frequency_bin_region.Rd
@@ -75,7 +75,7 @@ Alternatively, the region of interest can also be specified by calling the funct
 This function operates on a single region. To return a matrix of sliding window counts over multiple regions, see \link{calc_mutation_frequency_bin_region}Use .
 }
 \examples{
-chr11_mut_freq = calc_mutation_frequency_bin_region(region = "chr11:69455000-69459900",
+chr11_mut_freq = calc_mutation_frequency_bin_region(region = "11:69455000-69459900",
                                                          slide_by = 10,
                                                          window_size = 10000)
 

--- a/man/get_gene_expression.Rd
+++ b/man/get_gene_expression.Rd
@@ -13,8 +13,7 @@ get_gene_expression(
   all_genes = FALSE,
   expression_data,
   from_flatfile = TRUE,
-  default_priority = FALSE,
-  prioritize_rows_by
+  collapse_duplicates = TRUE
 )
 }
 \arguments{
@@ -35,13 +34,9 @@ get_gene_expression(
 
 \item{from_flatfile}{Deprecated but left here for backwards compatibility.}
 
-\item{default_priority}{A Boolean value (default is FALSE). If TRUE, duplications (as indicated by the \code{multi_exp}
+\item{collapse_duplicates}{A Boolean value (default is TRUE). If TRUE, duplications (as indicated by the \code{multi_exp}
 column of the output table) are filtered out using the default row prioritization. See the \strong{Details} section for
 more information.}
-
-\item{prioritize_rows_by}{A named list with one or more vectors. Provide this parameter if you want to filter out
-duplications (as indicated by the \code{multi_exp} column of the output table) by prioritizing rows based on the values
-of columns specified by this parameter. See the \strong{Details} section for more information.}
 }
 \value{
 A data frame with gene expression.
@@ -69,24 +64,12 @@ by directly matching them to mRNA sample IDs from the internal gene expression f
 than "mrna" (genome", "capture", or NULL), the function links the sample IDs by matching both patient and
 biopsy IDs from the metadata and from the expression files.
 
-The parameters \code{default_priority} or \code{prioritize_rows_by} may be used to prioritize rows and avoid duplications
-in the output table. A duplication is when a same sample ID from the metadata is linked to more than one mRNA
-sample ID from the internal gene expression file, hence the metadata sample ID is associated to more than one
-different expression level. To filter out duplications, either set \code{default_priority} to TRUE or provide to
-\code{prioritize_rows_by} a named list of vectors, where a name specifies a column (contained in the output) and
-its respective vector elements refer to possible values of this column to be prioritized. The first values of
-the vector have higher prioritization. First, filtering is applied using the column specified by the first
-element of list \code{prioritize_rows_by}. If any duplication remains, the next element is used, and so on. If
-\code{default_priority = TRUE}, default prioritization is used by deploying the following named list:
-
-\if{html}{\out{<div class="sourceCode">}}\preformatted{prioritize_rows_by = list(
-  protocol = c("Strand_Specific_Transcriptome_2",
-               "Strand_Specific_Transcriptome_3"),
-  ffpe_or_frozen = "frozen"
-)
-}\if{html}{\out{</div>}}
-
-If \code{default_priority = FALSE} and \code{prioritize_rows_by} is not provided, the filtering is not applied. If a
+The parameters \code{collapse_duplicates} may be used to prioritize rows and avoid duplications
+in the output table. A duplication is when the a sample ID from the metadata is linked to more than one mRNA
+sample ID from the internal gene expression file, hence the metadata sample ID is associated with more than one
+different expression level. If \code{collapse_duplicates} is TRUE (the default), duplications are filtered out by
+first prioritizing rows where the values in the \code{protocol} column match (using grep) the string \code{"Ribo"}. If
+any duplication remains, the \code{ffpe_or_frozen} column is used to match values to the \code{"frozen"} string. If a
 duplication can not be handled, its rows are marked as \code{1} in the output \code{multi_exp} column and a warning
 message is printed.
 }

--- a/man/get_gene_expression.Rd
+++ b/man/get_gene_expression.Rd
@@ -13,6 +13,7 @@ get_gene_expression(
   all_genes = FALSE,
   expression_data,
   from_flatfile = TRUE,
+  default_priority = FALSE,
   prioritize_rows_by
 )
 }
@@ -33,6 +34,10 @@ get_gene_expression(
 \item{expression_data}{Optional argument to use an already loaded expression data frame (prevent function to re-load full df from flat file or database).}
 
 \item{from_flatfile}{Deprecated but left here for backwards compatibility.}
+
+\item{default_priority}{A Boolean value (default is FALSE). If TRUE, duplications (as indicated by the \code{multi_exp}
+column of the output table) are filtered out using the default row prioritization. See the \strong{Details} section for
+more information.}
 
 \item{prioritize_rows_by}{A named list with one or more vectors. Provide this parameter if you want to filter out
 duplications (as indicated by the \code{multi_exp} column of the output table) by prioritizing rows based on the values
@@ -64,16 +69,15 @@ by directly matching them to mRNA sample IDs from the internal gene expression f
 than "mrna" (genome", "capture", or NULL), the function links the sample IDs by matching both patient and
 biopsy IDs from the metadata and from the expression files.
 
-The \code{prioritize_rows_by} parameter may be used to prioritize rows and avoid duplications in the output table.
-A duplication is when a same sample ID from the metadata is linked to more than one mRNA sample ID from the
-internal gene expression file, hence the metadata sample ID is associated to more than one different expression
-level. To filter out duplications, provide to \code{prioritize_rows_by} a named list of vectors, where a name
-specifies a column (contained in the output) and its respective vector elements refer to possible values of
-this column to be prioritized. The first values of the vector have higher prioritization. First, filtering is
-applied using the column specified by the first element of list \code{prioritize_rows_by}. If any duplication remains,
-the next element is used, and so on. This parameter is optional and if not provided, the filtering is not applied.
-If a duplication can not be solved, their rows will be marked as \code{1} in the output \code{multi_exp} column. Below is
-an example of how to set up the \code{prioritize_rows_by} parameter:
+The parameters \code{default_priority} or \code{prioritize_rows_by} may be used to prioritize rows and avoid duplications
+in the output table. A duplication is when a same sample ID from the metadata is linked to more than one mRNA
+sample ID from the internal gene expression file, hence the metadata sample ID is associated to more than one
+different expression level. To filter out duplications, either set \code{default_priority} to TRUE or provide to
+\code{prioritize_rows_by} a named list of vectors, where a name specifies a column (contained in the output) and
+its respective vector elements refer to possible values of this column to be prioritized. The first values of
+the vector have higher prioritization. First, filtering is applied using the column specified by the first
+element of list \code{prioritize_rows_by}. If any duplication remains, the next element is used, and so on. If
+\code{default_priority = TRUE}, default prioritization is used by deploying the following named list:
 
 \if{html}{\out{<div class="sourceCode">}}\preformatted{prioritize_rows_by = list(
   protocol = c("Strand_Specific_Transcriptome_2",
@@ -81,6 +85,10 @@ an example of how to set up the \code{prioritize_rows_by} parameter:
   ffpe_or_frozen = "frozen"
 )
 }\if{html}{\out{</div>}}
+
+If \code{default_priority = FALSE} and \code{prioritize_rows_by} is not provided, the filtering is not applied. If a
+duplication can not be handled, its rows are marked as \code{1} in the output \code{multi_exp} column and a warning
+message is printed.
 }
 \examples{
 MYC_expr = get_gene_expression(hugo_symbols = "MYC", join_with = "mrna")


### PR DESCRIPTION
In this PR, I added the parameter `default_priority` for default row prioritization. The default I'm using is:
```
list(
  protocol = c("Strand_Specific_Transcriptome_2",
               "Strand_Specific_Transcriptome_3"),
  ffpe_or_frozen = "frozen"
)
```

Please, let me know whether there is a more adequate default prioritization.
