### PR TITLE
Altered get_gambl_metadata2 to include promethION samples

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,3 +1,5 @@
+^renv$
+^renv\.lock$
 ^.*\.Rproj$
 ^\.Rproj\.user$
 ^LICENSE\.md$

--- a/R/get_gambl_metadata2.R
+++ b/R/get_gambl_metadata2.R
@@ -210,10 +210,10 @@ get_gambl_metadata = function(dna_seq_type_priority = "genome",
   }
 
   sample_meta_tumour_dna = sample_meta_tumour %>%
-    dplyr::filter(seq_type %in% c("genome","capture"))
+    dplyr::filter(seq_type %in% c("genome","capture", "promethION"))
 
   sample_meta_normal_dna = sample_meta_normal %>%
-    dplyr::filter(seq_type %in% c("genome","capture"))
+    dplyr::filter(seq_type %in% c("genome","capture", "promethION"))
 
 
   #helper function to prioritize systematically on the values in a column specified by column_name
@@ -248,6 +248,8 @@ get_gambl_metadata = function(dna_seq_type_priority = "genome",
   sample_meta_tumour_dna_capture = filter(sample_meta_tumour_dna,seq_type=="capture")
 
   sample_meta_tumour_dna_genome = filter(sample_meta_tumour_dna,seq_type=="genome")
+
+  sample_meta_tumour_dna_promethion = filter(sample_meta_tumour_dna,seq_type=="promethION")
 
   #prioritize within the genome seq_type (drop any FFPE where we have a frozen)
   if(verbose){
@@ -312,6 +314,7 @@ get_gambl_metadata = function(dna_seq_type_priority = "genome",
 
   all_meta_kept = bind_rows(sample_meta_tumour_dna_kept, filter(sample_meta_rna_kept,tissue_status=="tumour")) %>%
     ungroup() %>% select(-priority)
+  all_meta_kept = bind_rows(all_meta_kept, sample_meta_tumour_dna_promethion)
   all_meta_kept = left_join(all_meta_kept,biopsy_meta,by=c("patient_id","biopsy_id"))
   all_meta_kept = GAMBLR.utils::tidy_lymphgen(all_meta_kept,
                                          lymphgen_column_in = "lymphgen_cnv_noA53",


### PR DESCRIPTION
I noticed get_gambl_metadata was not returning promethION samples. I adjusted the function to include these instead of drop them.

Example (before and after):
```
meta <- get_gambl_metadata()

meta %>% count(seq_type)
```
Before:
```
# A tibble: 4 × 2
  seq_type       n
  <chr>      <int>
1 capture     3598
2 genome      1992
3 mrna        2373
```
After:
```
# A tibble: 4 × 2
  seq_type       n
  <chr>      <int>
1 capture     3598
2 genome      1992
3 mrna        2373
4 promethION    57
```