### PR TITLE
Reorder collate_results arguments to fix bug where function assumes sample_table is being passed

### DIFF
--- a/GAMBLR_examples_output.log
+++ b/GAMBLR_examples_output.log
@@ -1,5 +1,5 @@
-[1] "=== STARTED AT 2025-04-16 12:43:03 ==="
-── Running 71 example files ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── GAMBLR.results ──
+[1] "=== STARTED AT 2025-04-17 16:57:48 ==="
+── Running 71 example files ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── GAMBLR.results ──
 
 > my_metadata = suppressMessages(get_gambl_metadata())
 
@@ -833,4 +833,4 @@ Showing first 10 rows:
 
 > pretty_lymphoplot(meta_df, show_side_annotation = TRUE, 
 +     flavour = "with_cnvs.with_sv.no_A53")
-[1] "=== COMPLETED AT 2025-04-16 13:12:46 ==="
+[1] "=== COMPLETED AT 2025-04-17 17:46:38 ==="

--- a/R/collate_results.R
+++ b/R/collate_results.R
@@ -10,10 +10,10 @@
 #' If a dataframe is not provided, the function will default to all genome metadata returned with `get_gambl_metadata`. For more information on how to get the most out of this function,
 #' refer to function examples, vignettes and parameter descriptions.
 #'
-#' @param sample_table A data frame with sample_id as the first column (deprecated, use these_samples_metadata instead).
+#' @param these_samples_metadata Optional argument to use a user specified metadata df, must include seq_type column to specify desired seq types. If not provided, defaults to all genome samples with `get_gambl_metadata`. 
 #' @param write_to_file Boolean statement that outputs tsv file (/projects/nhl_meta_analysis_scratch/gambl/results_local/shared/gambl_{seq_type_filter}_results.tsv) if TRUE, default is FALSE.
 #' @param join_with_full_metadata Join with all columns of metadata, default is FALSE.
-#' @param these_samples_metadata Optional argument to use a user specified metadata df, must include seq_type column to specify desired seq types. If not provided, defaults to all genome samples with `get_gambl_metadata`. 
+#' @param sample_table A data frame with sample_id as the first column (deprecated, use these_samples_metadata instead).
 #' @param case_set Optional short name for a pre-defined set of cases.
 #' @param sbs_manipulation Optional variable for transforming sbs values (e.g log, scale).
 #' @param seq_type_filter Filtering criteria, default is genomes (deprecated. Include a `seq_type` column in these_samples_metadata to specify seq type).
@@ -48,10 +48,10 @@
 #'                               write_to_file = FALSE,
 #'                               from_cache = FALSE)
 #' dplyr::select(fl_collated, 1:14) %>% head()
-collate_results = function(sample_table,
+collate_results = function(these_samples_metadata,
                            write_to_file = FALSE,
                            join_with_full_metadata = FALSE,
-                           these_samples_metadata,
+                           sample_table,
                            case_set,
                            sbs_manipulation = "",
                            seq_type_filter = "genome",

--- a/man/collate_results.Rd
+++ b/man/collate_results.Rd
@@ -5,10 +5,10 @@
 \title{Collate Results}
 \usage{
 collate_results(
-  sample_table,
+  these_samples_metadata,
   write_to_file = FALSE,
   join_with_full_metadata = FALSE,
-  these_samples_metadata,
+  sample_table,
   case_set,
   sbs_manipulation = "",
   seq_type_filter = "genome",
@@ -16,13 +16,13 @@ collate_results(
 )
 }
 \arguments{
-\item{sample_table}{A data frame with sample_id as the first column (deprecated, use these_samples_metadata instead).}
+\item{these_samples_metadata}{Optional argument to use a user specified metadata df, must include seq_type column to specify desired seq types. If not provided, defaults to all genome samples with \code{get_gambl_metadata}.}
 
 \item{write_to_file}{Boolean statement that outputs tsv file (/projects/nhl_meta_analysis_scratch/gambl/results_local/shared/gambl_{seq_type_filter}_results.tsv) if TRUE, default is FALSE.}
 
 \item{join_with_full_metadata}{Join with all columns of metadata, default is FALSE.}
 
-\item{these_samples_metadata}{Optional argument to use a user specified metadata df, must include seq_type column to specify desired seq types. If not provided, defaults to all genome samples with \code{get_gambl_metadata}.}
+\item{sample_table}{A data frame with sample_id as the first column (deprecated, use these_samples_metadata instead).}
 
 \item{case_set}{Optional short name for a pre-defined set of cases.}
 


### PR DESCRIPTION
## Describe your changes

I noticed that collate_results(df) errors out even when providing a metadata with seq_type columns because the fxn assumes a sample table is being passed, this update just reorders the arguments

## Indicate which issue(s) this addresses, if applicable

## Checklist before requesting a review
- [x] I tested the new function/functionality in a fresh workspace
- [x] I added at least one working example that demonstrates the new functionality (*if applicable*)
- [x] The test script tools/logExampleOutputs.R ran to completion
- [x] I included the file `GAMBLR_examples_output.log` in my pull request and confirm the changes to this file are expected
