### PR TITLE
Apply curated blacklists by default to all ssm loading functions

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -69,4 +69,4 @@ Remotes:
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.3
+Config/roxygen2/version: 8.0.0

--- a/GAMBLR_examples_output.log
+++ b/GAMBLR_examples_output.log
@@ -1,12 +1,38 @@
-[1] "=== STARTED AT 2026-07-27 10:56:01 ==="
-[1] "=== RUNNING devtools::run_examples() ==="
-── Running 75 example files ──────────────────────────────── GAMBLR.results ──
+[1] "=== STARTED AT 2026-08-07 10:21:48.141673 ==="
+ℹ Updating GAMBLR.results documentation 
+Warning: replacing previous import ‘S4Arrays::makeNindexFromArrayViewport’ by ‘DelayedArray::makeNindexFromArrayViewport’ when loading ‘SummarizedExperiment’ 
+ℹ Loading GAMBLR.results 
+Warning: replacing previous import ‘IRanges::desc’ by ‘dplyr::desc’ when loading ‘GAMBLR.viz’ 
+Warning: replacing previous import ‘IRanges::slice’ by ‘dplyr::slice’ when loading ‘GAMBLR.viz’ 
+Warning: replacing previous import ‘IRanges::setdiff’ by ‘dplyr::setdiff’ when loading ‘GAMBLR.viz’ 
+Warning: replacing previous import ‘IRanges::intersect’ by ‘dplyr::intersect’ when loading ‘GAMBLR.viz’ 
+Warning: replacing previous import ‘IRanges::collapse’ by ‘dplyr::collapse’ when loading ‘GAMBLR.viz’ 
+Warning: replacing previous import ‘IRanges::union’ by ‘dplyr::union’ when loading ‘GAMBLR.viz’ 
+Warning: replacing previous import ‘cowplot::get_legend’ by ‘ggpubr::get_legend’ when loading ‘GAMBLR.viz’ 
+Warning: replacing previous import ‘IRanges::reduce’ by ‘purrr::reduce’ when loading ‘GAMBLR.viz’ 
+
+ 
+Warning: replacing previous import ‘BSgenome.Hsapiens.UCSC.hg19::Hsapiens’ by ‘BSgenome.Hsapiens.UCSC.hg38::Hsapiens’ when loading ‘GAMBLR.results’ 
+── Running 75 example files ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── GAMBLR.results ──
+ℹ Loading GAMBLR.results 
+Warning: replacing previous import ‘BSgenome.Hsapiens.UCSC.hg19::Hsapiens’ by ‘BSgenome.Hsapiens.UCSC.hg38::Hsapiens’ when loading ‘GAMBLR.results’ 
 
 > my_metadata = suppressMessages(get_gambl_metadata())
 
 > some_coding_ssm = get_coding_ssm(these_samples_metadata = my_metadata, 
 +     projection = "grch37", this_seq_type = "genome") %>% dplyr::filter(Hugo_Symbol %in% 
 +     c("EZH2", "MEF2B", "MYD88", "KMT2D")) %>% dplyr::arrange(Hugo_Symbol)
+Warning: The following named parsers don't match the column names: GENE_PHENO, FILTER, flanking_bps, vcf_id, vcf_qual, gnomAD_AF, gnomAD_AFR_AF, gnomAD_AMR_AF, gnomAD_SAS_AF, vcf_pos, gnomADg_AF, blacklist_count 
+Rows: 22 Columns: 4 
+── Column specification ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+Delimiter: "\t"
+chr (3): chrpos, Hugo_Symbol, Variant_Classification
+dbl (1): blacklist_count 
+
+ℹ Use `spec()` to retrieve the full column specification for this data.
+ℹ Specify the column types or set `show_col_types = FALSE` to quiet this message. 
+217 variants were dropped with the curated blacklist
+ 
 
 > dplyr::select(some_coding_ssm, 1:10, 37) %>% head()
 genomic_data Object
@@ -21,6 +47,8 @@ Showing first 10 rows:
 6        EZH2              0      .     GRCh37          7      148506437    148506437      +      Missense_Mutation          SNP     p.A692V
 
 > hot_ssms = annotate_hotspots(some_coding_ssm)
+Adding missing grouping variables: `SYMBOL` 
+Adding missing grouping variables: `SYMBOL` 
 
 > hot_ssms %>% dplyr::filter(!is.na(hot_spot)) %>% dplyr::select(1:10, 
 +     37, hot_spot)
@@ -40,6 +68,17 @@ Showing first 10 rows:
 10        EZH2              0      .     GRCh37          7      148508727    148508727      +      Missense_Mutation          SNP     p.Y646F     TRUE
 
 > maf <- get_coding_ssm(projection = "grch37") %>% head(n = 500)
+Warning: The following named parsers don't match the column names: GENE_PHENO, FILTER, flanking_bps, vcf_id, vcf_qual, gnomAD_AF, gnomAD_AFR_AF, gnomAD_AMR_AF, gnomAD_SAS_AF, vcf_pos, gnomADg_AF, blacklist_count 
+Rows: 22 Columns: 4 
+── Column specification ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+Delimiter: "\t"
+chr (3): chrpos, Hugo_Symbol, Variant_Classification
+dbl (1): blacklist_count 
+
+ℹ Use `spec()` to retrieve the full column specification for this data.
+ℹ Specify the column types or set `show_col_types = FALSE` to quiet this message. 
+218 variants were dropped with the curated blacklist
+ 
 
 > dplyr::select(maf, 1:12) %>% head()
 genomic_data Object
@@ -70,6 +109,17 @@ Showing first 10 rows:
 > my_maf <- get_coding_ssm() %>% dplyr::filter(Hugo_Symbol == 
 +     "BCL2") %>% dplyr::arrange(Chromosome, Start_Position, Tumor_Sample_Barcode) %>% 
 +     head()
+Warning: The following named parsers don't match the column names: GENE_PHENO, FILTER, flanking_bps, vcf_id, vcf_qual, gnomAD_AF, gnomAD_AFR_AF, gnomAD_AMR_AF, gnomAD_SAS_AF, vcf_pos, gnomADg_AF, blacklist_count 
+Rows: 22 Columns: 4 
+── Column specification ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+Delimiter: "\t"
+chr (3): chrpos, Hugo_Symbol, Variant_Classification
+dbl (1): blacklist_count 
+
+ℹ Use `spec()` to retrieve the full column specification for this data.
+ℹ Specify the column types or set `show_col_types = FALSE` to quiet this message. 
+218 variants were dropped with the curated blacklist
+ 
 
 > annotated = annotate_ssm_motif_context(maf = my_maf, 
 +     motif = "WRCY")
@@ -92,6 +142,12 @@ Showing first 10 rows:
 
 > mut_freq = calc_mutation_frequency_bin_region(these_samples_metadata = meta, 
 +     region = "11:69455000-69459900", slide_by = 10, window_size = 10000)
+processing bins of size 10000 across 4900 bp region
+ 
+Using GAMBLR.results::get_ssm_by_region...
+ 
+Joining with `by = join_by(sample_id)` 
+Joining with `by = join_by(window_start)` 
 
 > head(mut_freq)
 # A tibble: 6 × 3
@@ -106,15 +162,49 @@ Showing first 10 rows:
 
 > capture_metadata = get_gambl_metadata(dna_seq_type_priority = "capture") %>% 
 +     dplyr::filter(seq_type == "capture")
+3835 capture samples are missing a value for protocol. Assuming Exome.
+ 
+415 biopsies are missing from the biopsy metadata. This should be fixed!
+ 
+affected cohorts:  DLBCL_MER
+ 
+74 biopsies with discrepancies in the pathology field. This should be fixed!
+ 
+6 biopsies with discrepancies in the time_point field. This should be fixed!
+ 
+QC metrics for 6880 samples retrieved.
+ 
 
 > capture_collated_everything = collate_results(these_samples_metadata = capture_metadata, 
 +     from_cache = TRUE, write_to_file = FALSE)
 [[1]]
 /projects/nhl_meta_analysis_scratch/gambl/results_local/shared/gambl_capture_results.tsv
 
+Rows: 3110 Columns: 46 
+── Column specification ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+Delimiter: "\t"
+chr  (7): sample_id, patient_id, biopsy_id, BL_subgroup_validation_HTMCP, BL_subgroup_validation, genetic_subgroup, NFKBIZ_UTR
+dbl (23): total_ssm, mean_vaf, coding_ssm, ichorCNA_purity, ichorCNA_ploidy, ashm_BCL2, ashm_MYC, ashm_CCND1, AverageBaseQuality, AverageInsertSize, AverageReadLength, PairsOnDiffCHR, TotalReads, TotalUniquelyMapped, TotalUnmappedreads, TotalDuplicatedreads, ProportionReadsDuplicated, ProportionReadsMapped, MeanCorrectedCoverage, ProportionTargetsNoCoverage, ProportionCoverage10x, ProportionCoverage30x, PGA
+lgl (16): BL_subgroup_HTMCP, BL_subgroup, sample, total_reads, total_EBV, fraction_EBV, EBV_stats, manual_BCL2_sv, manual_BCL2_sv_notes, manual_contamination, manual_contamination_comments, manual_myc_sv, manual_myc_sv_comments, QC_flag, QC_comments, the_11q_event 
+
+ℹ Use `spec()` to retrieve the full column specification for this data.
+ℹ Specify the column types or set `show_col_types = FALSE` to quiet this message. 
+Joining with `by = join_by(sample_id, patient_id, biopsy_id, seq_type)` 
 
 > my_metadata = get_gambl_metadata() %>% dplyr::filter(seq_type != 
 +     "mrna")
+3835 capture samples are missing a value for protocol. Assuming Exome.
+ 
+415 biopsies are missing from the biopsy metadata. This should be fixed!
+ 
+affected cohorts:  DLBCL_MER
+ 
+74 biopsies with discrepancies in the pathology field. This should be fixed!
+ 
+6 biopsies with discrepancies in the time_point field. This should be fixed!
+ 
+QC metrics for 6880 samples retrieved.
+ 
 
 > fl_metadata = dplyr::filter(my_metadata, pathology == 
 +     "FL")
@@ -127,6 +217,25 @@ Showing first 10 rows:
 [[2]]
 /projects/nhl_meta_analysis_scratch/gambl/results_local/shared/gambl_capture_results.tsv
 
+Rows: 1744 Columns: 94 
+── Column specification ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+Delimiter: "\t"
+chr (31): sample_id, patient_id, biopsy_id, manta_MYC_sv, manta_MYC_partner, manta_BCL2_sv, manta_BCL2_partner, manta_BCL6_sv, manta_BCL6_partner, manta_CCND1_sv, manta_CCND1_partner, manta_IRF4_sv, manta_IRF4_partner, BL_subgroup_HTMCP, BL_subgroup, genetic_subgroup, sample, EBV_stats, manual_BCL2_sv, manual_BCL2_sv_notes, manual_myc_sv, manual_myc_sv_comments, QC_flag, QC_comments, NFKBIZ_UTR, Dominant_Ig_clone, mixcr_CSR, genome_CSR, CSR, predicted_ancestry, TargetSpace
+dbl (56): total_ssm, mean_vaf, coding_ssm, ichorCNA_purity, ichorCNA_ploidy, total_reads, total_EBV, fraction_EBV, ashm_BCL2, ashm_MYC, ashm_CCND1, proportion, PC1, PC2, PC3, PC4, PC5, SBS1, SBS2, SBS3, SBS5, SBS8, SBS13, SBS14, SBS15, SBS17a, SBS17b, SBS18, SBS26, SBS28, SBS29, SBS30, SBS41, SBS44, SBS53, SBS56, SBS85, SBS96J, SBS96K, SBS96L, SBS96N, AverageBaseQuality, AverageInsertSize, AverageReadLength, PairsOnDiffCHR, TotalReads, TotalUniquelyMapped, TotalUnmappedreads, TotalDuplicatedreads, ProportionReadsDuplicated, ProportionReadsMapped, Target_Territory, MeanCorrectedCoverage, ProportionCoverage10x, ProportionCoverage30x, PGA
+lgl  (7): BL_subgroup_validation_HTMCP, BL_subgroup_validation, manual_contamination, manual_contamination_comments, the_11q_event, ProportionTargetsNoCoverage, FoldEnrichment 
+
+ℹ Use `spec()` to retrieve the full column specification for this data.
+ℹ Specify the column types or set `show_col_types = FALSE` to quiet this message. 
+Rows: 3110 Columns: 46 
+── Column specification ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+Delimiter: "\t"
+chr  (7): sample_id, patient_id, biopsy_id, BL_subgroup_validation_HTMCP, BL_subgroup_validation, genetic_subgroup, NFKBIZ_UTR
+dbl (23): total_ssm, mean_vaf, coding_ssm, ichorCNA_purity, ichorCNA_ploidy, ashm_BCL2, ashm_MYC, ashm_CCND1, AverageBaseQuality, AverageInsertSize, AverageReadLength, PairsOnDiffCHR, TotalReads, TotalUniquelyMapped, TotalUnmappedreads, TotalDuplicatedreads, ProportionReadsDuplicated, ProportionReadsMapped, MeanCorrectedCoverage, ProportionTargetsNoCoverage, ProportionCoverage10x, ProportionCoverage30x, PGA
+lgl (16): BL_subgroup_HTMCP, BL_subgroup, sample, total_reads, total_EBV, fraction_EBV, EBV_stats, manual_BCL2_sv, manual_BCL2_sv_notes, manual_contamination, manual_contamination_comments, manual_myc_sv, manual_myc_sv_comments, QC_flag, QC_comments, the_11q_event 
+
+ℹ Use `spec()` to retrieve the full column specification for this data.
+ℹ Specify the column types or set `show_col_types = FALSE` to quiet this message. 
+Joining with `by = join_by(sample_id, patient_id, biopsy_id, seq_type)` 
 
 > my_meta = suppressMessages(get_gambl_metadata()) %>% 
 +     dplyr::filter(sample_id == "HTMCP-01-06-00422-01A-01D", seq_type == 
@@ -134,6 +243,11 @@ Showing first 10 rows:
 
 > outputs = estimate_purity(these = my_meta, show_plots = TRUE, 
 +     projection = "grch37")
+Warning: One or more parsing issues, call `problems()` on your data frame for details, e.g.:
+  dat <- vroom(...)
+  problems(dat) 
+Running in default mode of any...
+ 
 
 > outputs$sample_purity_estimation
 [1] 1
@@ -145,7 +259,7 @@ Showing first 10 rows:
 > table(maf_all_seqtype$maf_seq_type)
 
 capture  genome 
- 978167  241982 
+ 975346  241765 
 
 > dplyr::group_by(maf_all_seqtype, Hugo_Symbol, Variant_Classification) %>% 
 +     dplyr::count() %>% dplyr::arrange(desc(n))
@@ -166,6 +280,18 @@ Showing first 10 rows:
 
 > DLBCL_genome_meta = get_gambl_metadata() %>% dplyr::filter(pathology == 
 +     "DLBCL")
+3835 capture samples are missing a value for protocol. Assuming Exome.
+ 
+415 biopsies are missing from the biopsy metadata. This should be fixed!
+ 
+affected cohorts:  DLBCL_MER
+ 
+74 biopsies with discrepancies in the pathology field. This should be fixed!
+ 
+6 biopsies with discrepancies in the time_point field. This should be fixed!
+ 
+QC metrics for 6880 samples retrieved.
+ 
 
 > some_regions = GAMBLR.utils::create_bed_data(GAMBLR.data::grch37_ashm_regions, 
 +     fix_names = "concat", concat_cols = c("gene", "region"), 
@@ -173,6 +299,23 @@ Showing first 10 rows:
 
 > pax5_matrix <- get_ashm_count_matrix(regions_bed = some_regions, 
 +     this_seq_type = "genome", these_samples_metadata = DLBCL_genome_meta)
+Streamlined is set to TRUE, this function will disregard anything specified with basic_columns
+ 
+To return a MAF with standard 45 columns, set streamlined = FALSE and basic_columns = TRUE
+ 
+To return a maf with all (116) columns, set streamlined = FALSE and basic_columns = FALSE
+ 
+Rows: 22 Columns: 4 
+── Column specification ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+Delimiter: "\t"
+chr (3): chrpos, Hugo_Symbol, Variant_Classification
+dbl (1): blacklist_count 
+
+ℹ Use `spec()` to retrieve the full column specification for this data.
+ℹ Specify the column types or set `show_col_types = FALSE` to quiet this message. 
+0 variants were dropped with the curated blacklist
+ 
+Joining with `by = join_by(sample_id, region_name)` 
 
 > head(pax5_matrix)
                   PAX5-distal-enhancer-1 PAX5-distal-enhancer-2 PAX5-distal-enhancer-3 PAX5-intron-1 PAX5-TSS-1
@@ -216,6 +359,9 @@ Showing first 10 rows:
 +     genome_metadata)
 
 > all_seq_type_segs <- get_cn_segments(these_samples_metadata = mixed_seq_type_meta)
+Warning: One or more parsing issues, call `problems()` on your data frame for details, e.g.:
+  dat <- vroom(...)
+  problems(dat) 
 
 > dplyr::group_by(all_seq_type_segs, seg_seq_type) %>% 
 +     dplyr::count()
@@ -243,6 +389,9 @@ Showing first 10 rows:
 
 > genome_cnv_ssm_status = suppressMessages(get_cnv_and_ssm_status(genes_and_cn_threshs, 
 +     dplyr::filter(all_types_meta, seq_type == "genome"), only_cnv = "MIR17HG"))
+Warning: One or more parsing issues, call `problems()` on your data frame for details, e.g.:
+  dat <- vroom(...)
+  problems(dat) 
 
 > print(dim(genome_cnv_ssm_status))
 [1] 257   6
@@ -262,6 +411,13 @@ BLGSP-71-06-00007-01A-11D   1       0     1   1     0       0
 
 > all_seq_type_status = suppressMessages(get_cnv_and_ssm_status(genes_and_cn_threshs, 
 +     all_types_meta, only_cnv = "MIR17HG"))
+Warning: One or more parsing issues, call `problems()` on your data frame for details, e.g.:
+  dat <- vroom(...)
+  problems(dat) 
+Warning: There was 1 warning in `mutate()`.
+ℹ In argument: `log.ratio = log(CN/2, 2)`.
+Caused by warning:
+! NaNs produced 
 
 > print(dim(all_seq_type_status))
 [1] 407   6
@@ -280,9 +436,20 @@ BLGSP-71-06-00007-01A-11D   1       0     1   1     0       0
     283      63     118     194     186      21 
 
 > maf_genome = get_coding_ssm()
+Warning: The following named parsers don't match the column names: GENE_PHENO, FILTER, flanking_bps, vcf_id, vcf_qual, gnomAD_AF, gnomAD_AFR_AF, gnomAD_AMR_AF, gnomAD_SAS_AF, vcf_pos, gnomADg_AF, blacklist_count 
+Rows: 22 Columns: 4 
+── Column specification ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+Delimiter: "\t"
+chr (3): chrpos, Hugo_Symbol, Variant_Classification
+dbl (1): blacklist_count 
+
+ℹ Use `spec()` to retrieve the full column specification for this data.
+ℹ Specify the column types or set `show_col_types = FALSE` to quiet this message. 
+218 variants were dropped with the curated blacklist
+ 
 
 > nrow(maf_genome)
-[1] 323660
+[1] 323442
 
 > dplyr::select(maf_genome, 1, 4, 5, 6, 9, maf_seq_type)
 genomic_data Object
@@ -302,6 +469,20 @@ Showing first 10 rows:
 
 > maf_exome_hg38 = get_coding_ssm(this_seq_type = "capture", 
 +     projection = "hg38")
+Warning: The following named parsers don't match the column names: GENE_PHENO, FILTER, flanking_bps, vcf_id, vcf_qual, gnomAD_AF, gnomAD_AFR_AF, gnomAD_AMR_AF, gnomAD_SAS_AF, vcf_pos, gnomADg_AF, blacklist_count 
+Warning: One or more parsing issues, call `problems()` on your data frame for details, e.g.:
+  dat <- vroom(...)
+  problems(dat) 
+Rows: 22 Columns: 4 
+── Column specification ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+Delimiter: "\t"
+chr (3): chrpos, Hugo_Symbol, Variant_Classification
+dbl (1): blacklist_count 
+
+ℹ Use `spec()` to retrieve the full column specification for this data.
+ℹ Specify the column types or set `show_col_types = FALSE` to quiet this message. 
+2840 variants were dropped with the curated blacklist
+ 
 
 > dplyr::select(maf_exome_hg38, 1, 4, 5, 6, 9, maf_seq_type)
 genomic_data Object
@@ -333,6 +514,7 @@ capture  genome
 
 > coding_tabulated_df = get_coding_ssm_status(gene_symbols = genes, 
 +     include_hotspots = FALSE, genome_build = "hg38", these_samples_metadata = fl_meta)
+Joining with `by = join_by(sample_id)` 
 
 > length(genes)
 [1] 54
@@ -348,6 +530,7 @@ capture  genome
 
 > coding_tabulated2 = get_coding_ssm_status(gene_symbols = genes, 
 +     these_samples_metadata = fl_meta, maf_data = maf_data, include_hotspots = FALSE)
+Joining with `by = join_by(sample_id)` 
 
 > dim(coding_tabulated2)
 [1] 924  55
@@ -359,6 +542,22 @@ capture  genome
 +     "CREBBP", "KMT2D"), these_samples_metadata = fl_meta, maf_data = maf_data, 
 +     include_hotspots = TRUE, genes_of_interest = c("MYD88", "CREBBP")) %>% 
 +     tibble::column_to_rownames("sample_id")
+Joining with `by = join_by(sample_id)` 
+Adding missing grouping variables: `SYMBOL` 
+Adding missing grouping variables: `SYMBOL` 
+reviewing hotspots
+ 
+annotating hotspots
+ 
+Joining with `by = join_by(sample_id)` 
+CREBBPHOTSPOT
+ 
+OK
+ 
+MYD88HOTSPOT
+ 
+OK
+ 
 
 > print(colSums(coding_tabulated3))
         KMT2D        CREBBP         MYD88 CREBBPHOTSPOT  MYD88HOTSPOT 
@@ -458,13 +657,14 @@ Showing first 10 rows:
 +     genome_build = "hg38"))
 
 > head(annotated_myc_hg38)
-   chrom1    start1      end1 chrom2    start2      end2 name   score strand1 strand2          tumour_sample_id   gene partner    fusion
-1:     18  63123493  63123497      8 127728389 127728393    . 1742.36       +       -                 SU-DHL-10   BCL2    <NA>   NA-BCL2
-2:     18  63195263  63195266      8 127744561 127744564    .      NA       -       -                  SP194216   BCL2    <NA>   NA-BCL2
-3:      2  28983232  28983241      8 127711263 127711272    .      NA       -       -           02-14764_tumorB    ALK    <NA>    NA-ALK
-4:      3  70834666  70834671      8 127750318 127750323    .  249.44       -       + BLGSP-71-30-00661-01A-01E  FOXP1    <NA>  NA-FOXP1
-5:      3 101756651 101756656      8 127724888 127724893    .  261.80       +       - BLGSP-71-30-00676-01A-01E NFKBIZ    <NA> NA-NFKBIZ
-6:      3 187747200 187747205      8 127744763 127744768    .      NA       +       -           17-33848_tumorB   BCL6    <NA>   NA-BCL6
+   chrom1    start1      end1 chrom2    start2      end2   name   score strand1 strand2          tumour_sample_id   gene partner    fusion
+   <char>     <num>     <num> <char>     <num>     <num> <char>   <num>  <char>  <char>                    <char> <char>  <char>    <char>
+1:     18  63123493  63123497      8 127728389 127728393      . 1742.36       +       -                 SU-DHL-10   BCL2    <NA>   NA-BCL2
+2:     18  63195263  63195266      8 127744561 127744564      .      NA       -       -                  SP194216   BCL2    <NA>   NA-BCL2
+3:      2  28983232  28983241      8 127711263 127711272      .      NA       -       -           02-14764_tumorB    ALK    <NA>    NA-ALK
+4:      3  70834666  70834671      8 127750318 127750323      .  249.44       -       + BLGSP-71-30-00661-01A-01E  FOXP1    <NA>  NA-FOXP1
+5:      3 101756651 101756656      8 127724888 127724893      .  261.80       +       - BLGSP-71-30-00676-01A-01E NFKBIZ    <NA> NA-NFKBIZ
+6:      3 187747200 187747205      8 127744763 127744768      .      NA       +       -           17-33848_tumorB   BCL6    <NA>   NA-BCL6
 
 > table(annotated_myc_hg38$partner)
 
@@ -475,13 +675,14 @@ Showing first 10 rows:
 +     genome_build = "hg38"))
 
 > head(annotated_myc_incorrect)
-   chrom1    start1      end1 chrom2    start2      end2 name score strand1 strand2          tumour_sample_id gene partner fusion
-1:      8 127313080 127313571      8 128746007 128746587    .    NA       +       -                  PD26401c  MYC    <NA> NA-MYC
-2:      8 128738977 128738983      8 128752583 128752589    .    NA       +       -           04-14093_tumorA  MYC    <NA> NA-MYC
-3:      8 128738977 128738983      8 128752583 128752589    .    NA       +       -           04-14093_tumorB  MYC    <NA> NA-MYC
-4:      8 128738980 128738981      8 128752584 128752585    .    NA       +       - BLGSP-71-17-00357-01B-09E  MYC    <NA> NA-MYC
-5:      8 128738980 128738981      8 128752584 128752585    .    NA       +       - BLGSP-71-27-00424-01A-01E  MYC    <NA> NA-MYC
-6:      8 128738980 128738981      8 128752584 128752585    .    NA       +       -                SMZL-UK-T3  MYC    <NA> NA-MYC
+   chrom1    start1      end1 chrom2    start2      end2   name score strand1 strand2          tumour_sample_id   gene partner fusion
+   <char>     <num>     <num> <char>     <num>     <num> <char> <num>  <char>  <char>                    <char> <char>  <char> <char>
+1:      8 127313080 127313571      8 128746007 128746587      .    NA       +       -                  PD26401c    MYC    <NA> NA-MYC
+2:      8 128738977 128738983      8 128752583 128752589      .    NA       +       -           04-14093_tumorA    MYC    <NA> NA-MYC
+3:      8 128738977 128738983      8 128752583 128752589      .    NA       +       -           04-14093_tumorB    MYC    <NA> NA-MYC
+4:      8 128738980 128738981      8 128752584 128752585      .    NA       +       - BLGSP-71-17-00357-01B-09E    MYC    <NA> NA-MYC
+5:      8 128738980 128738981      8 128752584 128752585      .    NA       +       - BLGSP-71-27-00424-01A-01E    MYC    <NA> NA-MYC
+6:      8 128738980 128738981      8 128752584 128752585      .    NA       +       -                SMZL-UK-T3    MYC    <NA> NA-MYC
 
 > table(annotated_myc_incorrect$partner)
 < table of extent 0 >
@@ -523,9 +724,27 @@ Showing first 10 rows:
 6 01-20260T 14      106209408 106209409 18       60833799  60833800 IGH@  BCL2      0 +        -        known,oncogene,chimer2,cancer,tumor,m1,multi,oncokb,mitelman,ccle,reciprocal
 
 > my_meta = get_gambl_metadata()
+3835 capture samples are missing a value for protocol. Assuming Exome.
+ 
+415 biopsies are missing from the biopsy metadata. This should be fixed!
+ 
+affected cohorts:  DLBCL_MER
+ 
+74 biopsies with discrepancies in the pathology field. This should be fixed!
+ 
+6 biopsies with discrepancies in the time_point field. This should be fixed!
+ 
+QC metrics for 6880 samples retrieved.
+ 
 
 > lymphgen_all <- get_lymphgen(flavour = "no_cnvs.no_sv.with_A53", 
 +     these = my_meta, keep_original_columns = TRUE)
+NO A53
+ 
+Joining with `by = join_by(Sample.Name)` 
+Joining with `by = join_by(Sample.Name, BTG2)` 
+Joining with `by = join_by(Sample.Name)` 
+Joining with `by = join_by(Sample.Name, SOCS1)` 
 
 > head(lymphgen_all$features[, c(1:14)])
 # A tibble: 6 × 14
@@ -552,8 +771,30 @@ Showing first 10 rows:
 > all_sv <- get_manta_sv()
 [1] "no metadata provided, fetching all samples..."
 [1] "dropping capture samples because manta results\n      are only available for genome seq_type"
+
+The cached results were last updated: 2023-06-19 16:19:20.897737
+ 
+
+Reading cached results...
+
+ 
 [1] "No Manta SVs found for 711 samples and 18 cohorts"
  [1] "DLBCL_LSARP_Trios"   "tFL_LSARP_Trios"     "pFL_LSARP_Trios"     "MOHCCN"              "FL_FOLL_BR"          "DLBCL_TFRI_DarkZone" "PMBCL_Rai"           "DLBCL_Pasqualucci"   "DLBCL_montreal"      "DLBCL_Jain"          "DLBCL_cell_lines"    "PMBCL_Schleussner"   "MCL_CellLines"       "cHL_Maura"           "PMBCL_cell_lines"    "MM_mmsanger"         "SMZL_Strefford"      "Baylor_TXCRB"       
+
+The following VCF filters are applied;
+ 
+  Minimum VAF: 0.1
+ 
+  Minimum Score: 40
+ 
+  Only keep variants passing the quality filter: TRUE
+ 
+
+Returning 779327 variants from 1646 sample(s)
+ 
+
+Done!
+ 
 
 > dplyr::select(all_sv, 1:14) %>% head()
 genomic_data Object
@@ -632,13 +873,14 @@ Showing first 10 rows:
 +     genome_build = "hg38"))
 
 > head(annotated_myc_hg38)
-   chrom1    start1      end1 chrom2    start2      end2 name score strand1 strand2 tumour_sample_id  gene partner   fusion
-1:      2  28983233  28983240      8 127711264 127711271    .    43       -       -  02-14764_tumorB   ALK    <NA>   NA-ALK
-2:      3 187747202 187747205      8 127744764 127744767    .    79       +       -  17-33848_tumorB  BCL6    <NA>  NA-BCL6
-3:      3 187811601 187811601      8 127745649 127745649    .   106       -       +         FL1008T2  BCL6    <NA>  NA-BCL6
-4:      3 188074182 188074327      8 127749381 127749593    .    92       +       -      140127-PL02  BCL6    <NA>  NA-BCL6
-5:      4   1746419   1746421      8 127723483 127723485    .    77       -       -        09-41114T WHSC1    <NA> NA-WHSC1
-6:      8 127226860 127226862      8 127759782 127759784    .    56       +       +          SP13307   MYC    <NA>   NA-MYC
+   chrom1    start1      end1 chrom2    start2      end2   name score strand1 strand2 tumour_sample_id   gene partner   fusion
+   <char>     <num>     <num> <char>     <num>     <num> <char> <num>  <char>  <char>           <char> <char>  <char>   <char>
+1:      2  28983233  28983240      8 127711264 127711271      .    43       -       -  02-14764_tumorB    ALK    <NA>   NA-ALK
+2:      3 187747202 187747205      8 127744764 127744767      .    79       +       -  17-33848_tumorB   BCL6    <NA>  NA-BCL6
+3:      3 187811601 187811601      8 127745649 127745649      .   106       -       +         FL1008T2   BCL6    <NA>  NA-BCL6
+4:      3 188074182 188074327      8 127749381 127749593      .    92       +       -      140127-PL02   BCL6    <NA>  NA-BCL6
+5:      4   1746419   1746421      8 127723483 127723485      .    77       -       -        09-41114T  WHSC1    <NA> NA-WHSC1
+6:      8 127226860 127226862      8 127759782 127759784      .    56       +       +          SP13307    MYC    <NA>   NA-MYC
 
 > table(annotated_myc_hg38$partner)
 
@@ -649,13 +891,14 @@ Showing first 10 rows:
 +     genome_build = "hg38"))
 
 > head(annotated_myc_incorrect)
-   chrom1    start1      end1 chrom2    start2      end2 name score strand1 strand2 tumour_sample_id gene partner fusion
-1:      8 128726344 128727379     11  93629113  93629647    .    66       -       +        01-20774T  MYC    <NA> NA-MYC
-2:      8 128726820 128726820      8 128726825 128726825    .    76       +       -         PD26403a  MYC    <NA> NA-MYC
-3:      8 128726820 128726820      8 128726825 128726825    .    84       +       -         PD26403c  MYC    <NA> NA-MYC
-4:      8 128738979 128738983      8 128752584 128752588    .   118       +       -  04-14093_tumorA  MYC    <NA> NA-MYC
-5:      8 128738979 128738983      8 128752584 128752588    .   127       +       -  04-14093_tumorB  MYC    <NA> NA-MYC
-6:      8 128738981 128738981      8 128752584 128752584    .   126       +       -        05-24065T  MYC    <NA> NA-MYC
+   chrom1    start1      end1 chrom2    start2      end2   name score strand1 strand2 tumour_sample_id   gene partner fusion
+   <char>     <num>     <num> <char>     <num>     <num> <char> <num>  <char>  <char>           <char> <char>  <char> <char>
+1:      8 128726344 128727379     11  93629113  93629647      .    66       -       +        01-20774T    MYC    <NA> NA-MYC
+2:      8 128726820 128726820      8 128726825 128726825      .    76       +       -         PD26403a    MYC    <NA> NA-MYC
+3:      8 128726820 128726820      8 128726825 128726825      .    84       +       -         PD26403c    MYC    <NA> NA-MYC
+4:      8 128738979 128738983      8 128752584 128752588      .   118       +       -  04-14093_tumorA    MYC    <NA> NA-MYC
+5:      8 128738979 128738983      8 128752584 128752588      .   127       +       -  04-14093_tumorB    MYC    <NA> NA-MYC
+6:      8 128738981 128738981      8 128752584 128752584      .   126       +       -        05-24065T    MYC    <NA> NA-MYC
 
 > table(annotated_myc_incorrect$partner)
 < table of extent 0 >
@@ -667,6 +910,16 @@ Showing first 10 rows:
 > test_genes = c("EZH2", "KMT2D", "MYD88", "ID3", "FOXO1")
 
 > test_maf = get_ssm_by_genes(genes = test_genes, these_samples_metadata = test_meta)
+Rows: 22 Columns: 4 
+── Column specification ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+Delimiter: "\t"
+chr (3): chrpos, Hugo_Symbol, Variant_Classification
+dbl (1): blacklist_count 
+
+ℹ Use `spec()` to retrieve the full column specification for this data.
+ℹ Specify the column types or set `show_col_types = FALSE` to quiet this message. 
+0 variants were dropped with the curated blacklist
+ 
 
 > dplyr::count(test_maf, Hugo_Symbol, sort = TRUE)
 genomic_data Object
@@ -681,6 +934,16 @@ Showing first 10 rows:
 
 > hist_maf = get_ssm_by_genes(genes = "HIST1H1C", these_samples_metadata = test_meta, 
 +     projection = "hg38")
+Rows: 22 Columns: 4 
+── Column specification ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+Delimiter: "\t"
+chr (3): chrpos, Hugo_Symbol, Variant_Classification
+dbl (1): blacklist_count 
+
+ℹ Use `spec()` to retrieve the full column specification for this data.
+ℹ Specify the column types or set `show_col_types = FALSE` to quiet this message. 
+0 variants were dropped with the curated blacklist
+ 
 
 > dplyr::count(hist_maf, Hugo_Symbol, sort = TRUE)
 genomic_data Object
@@ -691,6 +954,18 @@ Showing first 10 rows:
 
 > genomes = get_gambl_metadata() %>% dplyr::filter(seq_type %in% 
 +     "genome")
+3835 capture samples are missing a value for protocol. Assuming Exome.
+ 
+415 biopsies are missing from the biopsy metadata. This should be fixed!
+ 
+affected cohorts:  DLBCL_MER
+ 
+74 biopsies with discrepancies in the pathology field. This should be fixed!
+ 
+6 biopsies with discrepancies in the time_point field. This should be fixed!
+ 
+QC metrics for 6880 samples retrieved.
+ 
 
 > my_mutations = GAMBLR.results:::get_ssm_by_region(region = "chr8:128723128-128774067", 
 +     these_samples_metadata = genomes)
@@ -707,6 +982,16 @@ Showing first 10 rows:
 
 > ashm_MAF = get_ssm_by_regions(regions_bed = regions_bed, 
 +     these_samples_metadata = DLBCL_meta, streamlined = FALSE)
+Rows: 22 Columns: 4 
+── Column specification ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+Delimiter: "\t"
+chr (3): chrpos, Hugo_Symbol, Variant_Classification
+dbl (1): blacklist_count 
+
+ℹ Use `spec()` to retrieve the full column specification for this data.
+ℹ Specify the column types or set `show_col_types = FALSE` to quiet this message. 
+0 variants were dropped with the curated blacklist
+ 
 
 > ashm_MAF %>% dplyr::arrange(Start_Position, Tumor_Sample_Barcode) %>% 
 +     dplyr::select(Hugo_Symbol, Tumor_Sample_Barcode, Chromosome, 
@@ -728,12 +1013,36 @@ Showing first 10 rows:
 
 > maf_samp = GAMBLR.results:::get_ssm_by_sample(get_gambl_metadata() %>% 
 +     dplyr::filter(sample_id == "13-27975_tumorA"), augmented = FALSE)
+3835 capture samples are missing a value for protocol. Assuming Exome.
+ 
+415 biopsies are missing from the biopsy metadata. This should be fixed!
+ 
+affected cohorts:  DLBCL_MER
+ 
+74 biopsies with discrepancies in the pathology field. This should be fixed!
+ 
+6 biopsies with discrepancies in the time_point field. This should be fixed!
+ 
+QC metrics for 6880 samples retrieved.
+ 
 
 > nrow(maf_samp)
 [1] 4705
 
 > maf_samp_aug = GAMBLR.results:::get_ssm_by_sample(get_gambl_metadata() %>% 
 +     dplyr::filter(sample_id == "13-27975_tumorA"), augmented = TRUE)
+3835 capture samples are missing a value for protocol. Assuming Exome.
+ 
+415 biopsies are missing from the biopsy metadata. This should be fixed!
+ 
+affected cohorts:  DLBCL_MER
+ 
+74 biopsies with discrepancies in the pathology field. This should be fixed!
+ 
+6 biopsies with discrepancies in the time_point field. This should be fixed!
+ 
+QC metrics for 6880 samples retrieved.
+ 
 
 > nrow(maf_samp_aug)
 [1] 6118
@@ -741,6 +1050,18 @@ Showing first 10 rows:
 > some_maf = GAMBLR.results:::get_ssm_by_sample(these_samples_metadata = get_gambl_metadata() %>% 
 +     dplyr::filter(sample_id == "HTMCP-01-06-00485-01A-01D", seq_type == 
 +         "genome"), projection = "hg38")
+3835 capture samples are missing a value for protocol. Assuming Exome.
+ 
+415 biopsies are missing from the biopsy metadata. This should be fixed!
+ 
+affected cohorts:  DLBCL_MER
+ 
+74 biopsies with discrepancies in the pathology field. This should be fixed!
+ 
+6 biopsies with discrepancies in the time_point field. This should be fixed!
+ 
+QC metrics for 6880 samples retrieved.
+ 
 
 > dplyr::select(some_maf, 1:10)
 genomic_data Object
@@ -760,14 +1081,62 @@ Showing first 10 rows:
 
 > nonsyn_maf = GAMBLR.results:::get_ssm_by_sample(get_gambl_metadata() %>% 
 +     dplyr::filter(sample_id == "13-27975_tumorA"), variant_classification_filter = GAMBLR.helpers::vc_nonSynonymous)
+3835 capture samples are missing a value for protocol. Assuming Exome.
+ 
+415 biopsies are missing from the biopsy metadata. This should be fixed!
+ 
+affected cohorts:  DLBCL_MER
+ 
+74 biopsies with discrepancies in the pathology field. This should be fixed!
+ 
+6 biopsies with discrepancies in the time_point field. This should be fixed!
+ 
+QC metrics for 6880 samples retrieved.
+ 
 
 > my_meta = get_gambl_metadata() %>% dplyr::filter(sample_id %in% 
 +     c("HTMCP-01-06-00485-01A-01D", "14-35472_tumorA", "14-35472_tumorB"))
+3835 capture samples are missing a value for protocol. Assuming Exome.
+ 
+415 biopsies are missing from the biopsy metadata. This should be fixed!
+ 
+affected cohorts:  DLBCL_MER
+ 
+74 biopsies with discrepancies in the pathology field. This should be fixed!
+ 
+6 biopsies with discrepancies in the time_point field. This should be fixed!
+ 
+QC metrics for 6880 samples retrieved.
+ 
 
 > sample_ssms = get_ssm_by_samples(these_samples_metadata = my_meta)
+Merged 3 samples for seq_type genome
+ 
+Rows: 22 Columns: 4 
+── Column specification ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+Delimiter: "\t"
+chr (3): chrpos, Hugo_Symbol, Variant_Classification
+dbl (1): blacklist_count 
+
+ℹ Use `spec()` to retrieve the full column specification for this data.
+ℹ Specify the column types or set `show_col_types = FALSE` to quiet this message. 
+0 variants were dropped with the curated blacklist
+ 
 
 > hg38_ssms = get_ssm_by_samples(projection = "hg38", 
 +     these_samples_metadata = my_meta)
+Merged 3 samples for seq_type genome
+ 
+Rows: 22 Columns: 4 
+── Column specification ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+Delimiter: "\t"
+chr (3): chrpos, Hugo_Symbol, Variant_Classification
+dbl (1): blacklist_count 
+
+ℹ Use `spec()` to retrieve the full column specification for this data.
+ℹ Specify the column types or set `show_col_types = FALSE` to quiet this message. 
+0 variants were dropped with the curated blacklist
+ 
 
 > dplyr::group_by(hg38_ssms, Tumor_Sample_Barcode) %>% 
 +     dplyr::count()
@@ -781,6 +1150,18 @@ Showing first 10 rows:
 
 > hg38_ssms_no_aug = get_ssm_by_samples(projection = "hg38", 
 +     these_samples_metadata = my_meta, augmented = FALSE)
+Merged 3 samples for seq_type genome
+ 
+Rows: 22 Columns: 4 
+── Column specification ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+Delimiter: "\t"
+chr (3): chrpos, Hugo_Symbol, Variant_Classification
+dbl (1): blacklist_count 
+
+ℹ Use `spec()` to retrieve the full column specification for this data.
+ℹ Specify the column types or set `show_col_types = FALSE` to quiet this message. 
+0 variants were dropped with the curated blacklist
+ 
 
 > dplyr::group_by(hg38_ssms_no_aug, Tumor_Sample_Barcode) %>% 
 +     dplyr::count()
@@ -804,21 +1185,93 @@ Showing first 10 rows:
 
 > genomes <- get_gambl_metadata() %>% dplyr::filter(seq_type == 
 +     "genome")
+3835 capture samples are missing a value for protocol. Assuming Exome.
+ 
+415 biopsies are missing from the biopsy metadata. This should be fixed!
+ 
+affected cohorts:  DLBCL_MER
+ 
+74 biopsies with discrepancies in the pathology field. This should be fixed!
+ 
+6 biopsies with discrepancies in the time_point field. This should be fixed!
+ 
+QC metrics for 6880 samples retrieved.
+ 
 
 > genome_maf <- get_ssm_by_regions(regions_bed = myc_grch37, 
 +     these_samples_metadata = genomes, streamlined = FALSE, basic_columns = TRUE)
+Rows: 22 Columns: 4 
+── Column specification ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+Delimiter: "\t"
+chr (3): chrpos, Hugo_Symbol, Variant_Classification
+dbl (1): blacklist_count 
+
+ℹ Use `spec()` to retrieve the full column specification for this data.
+ℹ Specify the column types or set `show_col_types = FALSE` to quiet this message. 
+0 variants were dropped with the curated blacklist
+ 
 
 > maf_to_custom_track(maf_data = genome_maf, output_file = "myc_genome_hg19.bed")
+3835 capture samples are missing a value for protocol. Assuming Exome.
+ 
+415 biopsies are missing from the biopsy metadata. This should be fixed!
+ 
+affected cohorts:  DLBCL_MER
+ 
+74 biopsies with discrepancies in the pathology field. This should be fixed!
+ 
+6 biopsies with discrepancies in the time_point field. This should be fixed!
+ 
+QC metrics for 6880 samples retrieved.
+ 
+Joining with `by = join_by(group)` 
 
 > my_region = "8:128747680-128753674"
 
 > captures <- get_gambl_metadata() %>% dplyr::filter(seq_type == 
 +     "capture")
+3835 capture samples are missing a value for protocol. Assuming Exome.
+ 
+415 biopsies are missing from the biopsy metadata. This should be fixed!
+ 
+affected cohorts:  DLBCL_MER
+ 
+74 biopsies with discrepancies in the pathology field. This should be fixed!
+ 
+6 biopsies with discrepancies in the time_point field. This should be fixed!
+ 
+QC metrics for 6880 samples retrieved.
+ 
 
 > capture_maf <- get_ssm_by_regions(regions_list = my_region, 
 +     these_samples_metadata = captures, projection = "grch37", 
 +     streamlined = FALSE, basic_columns = TRUE)
+Rows: 22 Columns: 4 
+── Column specification ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+Delimiter: "\t"
+chr (3): chrpos, Hugo_Symbol, Variant_Classification
+dbl (1): blacklist_count 
+
+ℹ Use `spec()` to retrieve the full column specification for this data.
+ℹ Specify the column types or set `show_col_types = FALSE` to quiet this message. 
+0 variants were dropped with the curated blacklist
+ 
 
 > maf_to_custom_track(maf_data = capture_maf, this_seq_type = "capture", 
 +     output_file = "myc_capture_hg19.bed")
-[1] "=== COMPLETED AT 2026-07-27 11:10:53 ==="
+3835 capture samples are missing a value for protocol. Assuming Exome.
+ 
+415 biopsies are missing from the biopsy metadata. This should be fixed!
+ 
+affected cohorts:  DLBCL_MER
+ 
+74 biopsies with discrepancies in the pathology field. This should be fixed!
+ 
+6 biopsies with discrepancies in the time_point field. This should be fixed!
+ 
+QC metrics for 6880 samples retrieved.
+ 
+Joining with `by = join_by(group)` 
+ℹ Loading GAMBLR.results 
+Warning: replacing previous import ‘BSgenome.Hsapiens.UCSC.hg19::Hsapiens’ by ‘BSgenome.Hsapiens.UCSC.hg38::Hsapiens’ when loading ‘GAMBLR.results’ 
+[1] "=== COMPLETED AT 2026-08-07 10:38:19.856845 ==="

--- a/R/annotate_ssm_blacklist.R
+++ b/R/annotate_ssm_blacklist.R
@@ -130,20 +130,28 @@ annotate_ssm_blacklist = function(mutations_df,
     readr::read_tsv()
 
     additional_blacklist = additional_blacklist %>%
+      dplyr::select(chrpos, blacklist_count_bespoke = blacklist_count) %>% 
       separate(chrpos, into = c("Chromosome", "Start_Position"), sep = ":") %>% 
       mutate(Start_Position = as.numeric(Start_Position))
 
-    mutations_df = left_join(mutations_df, additional_blacklist, by = c("Chromosome", "Start_Position")) %>%
-      mutate(blacklist_count = tidyr::replace_na(blacklist_count, 0))
+    # mutations_df might not already have a blacklist_count column - if not, add an empty one
+    if(!"blacklist_count" %in% colnames(mutations_df)){
+      mutations_df$blacklist_count = rep.int(0, length(mutations_df$Tumor_Sample_Barcode))
+    }
+
+    mutations_df = left_join(mutations_df, additional_blacklist, by = c("Chromosome", "Start_Position")) %>% 
+      mutate(blacklist_count = ifelse(!is.na(blacklist_count_bespoke), blacklist_count_bespoke, blacklist_count)) %>% 
+      mutate(blacklist_count = replace_na(blacklist_count, 0)) %>% 
+      select(-blacklist_count_bespoke)
 
     dropped = dplyr::filter(mutations_df, blacklist_count > drop_threshold)
 
     if(verbose){
       if(nrow(dropped) > 0 ){
         ndrop = length(dropped$Tumor_Sample_Barcode)
-        message(paste(ndrop, "variants were dropped"))
+        message(paste(ndrop, "variants were dropped with the curated blacklist"))
       } else {
-        message("0 variants were dropped")
+        message("0 variants were dropped with the curated blacklist")
       }
     }
   }

--- a/R/get_all_coding_ssm.R
+++ b/R/get_all_coding_ssm.R
@@ -10,6 +10,7 @@
 #' sample/seq_type combinations you want. 
 #' @param include_silent If set to TRUE, silent/synonymous mutations in the
 #' coding regions will also be returned. Default is FALSE.
+#' @param apply_curated_blacklist Filter variants that appear in the curated blacklist as specified under config::get("resources")$curated_blacklist. Default: TRUE. 
 #' @param ... Additional arguments passed to get_coding_ssm
 #'
 #' @return A data frame containing all the MAF data columns (one row per
@@ -30,6 +31,7 @@
 #'   dplyr::arrange(desc(n))
 get_all_coding_ssm = function(these_samples_metadata = NULL,
                               include_silent=FALSE,
+                              apply_curated_blacklist=TRUE, 
                               ...){
   if(missing(these_samples_metadata)){
     stop("these_samples_metadata is required")
@@ -42,7 +44,8 @@ get_all_coding_ssm = function(these_samples_metadata = NULL,
                                  dplyr::filter(these_samples_metadata,
                                                seq_type=="capture"),
                                this_seq_type = "capture",
-                               include_silent = include_silent,
+                               include_silent = include_silent, 
+                               apply_curated_blacklist=apply_curated_blacklist,
                                ...))) 
   }
   if("genome" %in% seq_types_in_metadata){
@@ -50,7 +53,8 @@ get_all_coding_ssm = function(these_samples_metadata = NULL,
                                 dplyr::filter(these_samples_metadata,
                                               seq_type=="genome"),
                               this_seq_type = "genome", 
-                              include_silent = include_silent,
+                              include_silent = include_silent, 
+                               apply_curated_blacklist=apply_curated_blacklist,
                               ...)))
      
   }

--- a/R/get_cnv_and_ssm_status.R
+++ b/R/get_cnv_and_ssm_status.R
@@ -35,6 +35,7 @@
 #'   ignoring SSM status. Set this argument to "all" or "none" (default) to apply this behavior to all or none 
 #'   of the genes, respectively.
 #' @param genome_build Reference genome build. Possible values are "grch37" (default) or "hg38".
+#' @param apply_curated_blacklist Filter variants that appear in the curated blacklist as specified under config::get("resources")$curated_blacklist. Default: TRUE. 
 
 #' @param include_hotspots Logical parameter indicating whether
 #' hotspots object should also be tabulated. Default is TRUE.
@@ -105,6 +106,7 @@ get_cnv_and_ssm_status = function(genes_and_cn_threshs,
                                   adjust_for_ploidy=TRUE,
                                   include_silent=FALSE,
                                   binary = TRUE,
+                                  apply_curated_blacklist = TRUE,
                                   this_seq_type){
   
   # check parameters
@@ -276,7 +278,8 @@ get_cnv_and_ssm_status = function(genes_and_cn_threshs,
     my_maf = get_all_coding_ssm(
       these_samples_metadata = these_samples_metadata,
       projection = genome_build,
-      include_silent = include_silent
+      include_silent = include_silent, 
+      apply_curated_blacklist = apply_curated_blacklist
     ) %>%
       dplyr::filter(Hugo_Symbol %in% genes_to_check_ssm)
   }else{
@@ -292,7 +295,8 @@ get_cnv_and_ssm_status = function(genes_and_cn_threshs,
     genome_build = genome_build,
     min_read_support = min_read_support_ssm,
     include_hotspots = include_hotspots,
-    include_silent = FALSE,
+    include_silent = FALSE, 
+    apply_curated_blacklist = apply_curated_blacklist,
     augmented = augmented
   ) 
  

--- a/R/get_coding_ssm.R
+++ b/R/get_coding_ssm.R
@@ -52,6 +52,7 @@
 #' @param exclude_cohort  Deprecated. Use these_samples_metadata instead.
 #' @param limit_pathology Deprecated. Use these_samples_metadata instead.
 #' @param limit_samples Deprecated. Use these_samples_metadata instead.
+#' @param apply_curated_blacklist Filter variants that appear in the curated blacklist as specified under config::get("resources")$curated_blacklist. Default: TRUE. 
 #'
 #' @return A data frame containing all the MAF data columns
 #' (one row per mutation).
@@ -90,6 +91,7 @@ get_coding_ssm = function(these_samples_metadata = NULL,
                           limit_pathology,
                           limit_samples,
                           from_flatfile,
+                          apply_curated_blacklist = TRUE, 
                           these_sample_ids){
   
 
@@ -187,5 +189,15 @@ get_coding_ssm = function(these_samples_metadata = NULL,
   
   muts = mutate(muts,maf_seq_type = this_seq_type)
   muts = GAMBLR.utils::create_maf_data(muts,projection)
+  if(apply_curated_blacklist){
+      muts = annotate_ssm_blacklist(
+        mutations_df = muts, 
+        this_seq_type = unique(muts$maf_seq_type), 
+        genome_build = projection, 
+        use_curated_blacklist = TRUE, 
+        verbose = TRUE
+      ) %>% 
+      select(-blacklist_count)
+    }
   return(muts)
 }

--- a/R/get_coding_ssm_status.R
+++ b/R/get_coding_ssm_status.R
@@ -59,6 +59,7 @@
 #' @param include_silent_genes Optionally, provide a list of genes for which the
 #'      Silent variants to be considered. If provided, the Silent variants for
 #'      these genes will be included regardless of the include_silent argument.
+#' @param apply_curated_blacklist Filter variants that appear in the curated blacklist as specified under config::get("resources")$curated_blacklist. Default: TRUE. 
 #' @param suffix Optionally provide a character that will be appended to the end of each name
 #' @param this_seq_type Deprecated. This is now determined from the metadata provided.
 #'
@@ -129,6 +130,7 @@ get_coding_ssm_status = function(
     genome_build,
     include_silent = FALSE,
     include_silent_genes,
+    apply_curated_blacklist=TRUE,
     suffix,
     this_seq_type
 ){
@@ -188,6 +190,7 @@ get_coding_ssm_status = function(
                                       these_samples_metadata = these_samples_metadata,
                                       augmented = augmented,
                                       basic_columns = FALSE,
+                                      apply_curated_blacklist = apply_curated_blacklist,
                                       include_silent = include_silent)
 
   }

--- a/R/get_ssm_by_genes.R
+++ b/R/get_ssm_by_genes.R
@@ -21,6 +21,7 @@
 #' span (promoter/UTR/annotation-source discrepancies, e.g. a long first
 #' intron) are never fetched in the first place, and the Hugo_Symbol filter
 #' below can't recover rows that were never pulled.
+#' @param apply_curated_blacklist Filter variants that appear in the curated blacklist as specified under config::get("resources")$curated_blacklist. Default: TRUE. 
 #' @param projection Obtain variants projected to this reference (one of grch37 or hg38).
 #'
 #' @return A data frame containing all the MAF data columns (one row per mutation).
@@ -73,6 +74,7 @@ get_ssm_by_genes = function(genes,
                            ashm_regions,
                            drop_silent_outside_ashm_regions = FALSE,
                            expand_by = 10000,
+                           apply_curated_blacklist = TRUE,
                            verbose = FALSE) {
 
     all_ssms = list()
@@ -138,6 +140,17 @@ get_ssm_by_genes = function(genes,
         columns2=c("chrom","ashm_region_start","ashm_region_end"))
         all_ssm_maf = bind_rows(silent_ssm_maf,coding_ssm_maf)
     }
+  # Apply curated blacklist if requested (default)
+  if(apply_curated_blacklist){
+    all_ssm_maf = annotate_ssm_blacklist(
+        mutations_df = all_ssm_maf, 
+        this_seq_type = unique(these_samples_metadata$seq_type), 
+        genome_build = projection, 
+        use_curated_blacklist = TRUE, 
+        verbose = TRUE
+      ) %>% 
+      select(-blacklist_count)
+  }
   all_ssm_maf = create_maf_data(all_ssm_maf, genome_build = projection)
   return(all_ssm_maf)
 }

--- a/R/get_ssm_by_regions.R
+++ b/R/get_ssm_by_regions.R
@@ -36,6 +36,7 @@
 #' @param projection Obtain variants projected to this reference, one of grch37 (default) or hg38.
 #' @param min_read_support Only returns variants with at least this many reads in t_alt_count
 #'  (for cleaning up augmented MAFs). Default: 3.
+#' @param apply_curated_blacklist Filter variants that appear in the curated blacklist as specified under config::get("resources")$curated_blacklist. Default: TRUE. 
 #' @param verbose Boolean parameter set to FALSE per default.
 #' @param this_seq_type Deprecated. Inferred from these_samples_metadata.
 #' @param these_sample_ids Deprecated. Inferred from these_samples_metadata.
@@ -78,6 +79,7 @@ get_ssm_by_regions = function(regions_list,
                               augmented = TRUE,
                               projection = "grch37",
                               min_read_support = 3,
+                              apply_curated_blacklist = TRUE, 
                               verbose = FALSE,
                               these_sample_ids,
                               this_seq_type){
@@ -268,6 +270,17 @@ get_ssm_by_regions = function(regions_list,
     }
     muts_all = do.call("rbind", seq_type_muts_region)
 
+    if(apply_curated_blacklist){
+      muts_all = annotate_ssm_blacklist(
+        mutations_df = muts_all, 
+        this_seq_type = unique(these_samples_metadata$seq_type), 
+        genome_build = projection, 
+        use_curated_blacklist = TRUE, 
+        verbose = TRUE
+      ) %>% 
+      select(-blacklist_count)
+    }
+
     if(streamlined){
       # Need a per-row region label; cheap now since muts_all only contains
       # rows tabix already matched to the requested regions. Reuses the
@@ -323,6 +336,17 @@ get_ssm_by_regions = function(regions_list,
     }
 
     region_mafs <- list_rbind(region_mafs, names_to = "region_name")
+    # Apply curated blacklist if requested (default)
+    if(apply_curated_blacklist){
+      region_mafs = annotate_ssm_blacklist(
+        mutations_df = region_mafs, 
+        this_seq_type = unique(these_samples_metadata$seq_type), 
+        genome_build = projection, 
+        use_curated_blacklist = TRUE, 
+        verbose = TRUE
+      ) %>% 
+      select(-blacklist_count)
+    }
     if(streamlined){
       region_mafs = mutate(region_mafs, start = Start_Position, sample_id =Tumor_Sample_Barcode) %>%
         dplyr::select(start, sample_id, region_name)

--- a/R/get_ssm_by_samples.R
+++ b/R/get_ssm_by_samples.R
@@ -44,6 +44,7 @@
 #' @param subset_from_merge Instead of merging individual MAFs,
 #' the data will be subset from a pre-merged MAF of samples with
 #' the specified this_seq_type.
+#' @param apply_curated_blacklist Filter variants that appear in the curated blacklist as specified under config::get("resources")$curated_blacklist. Default: TRUE. 
 #' @param engine Specify one of readr or fread_maf (default) to
 #' change how the large files are loaded prior to subsetting.
 #' You may have better performance with one or the other.
@@ -91,6 +92,7 @@ get_ssm_by_samples = function(these_samples_metadata,
                               variant_classification_filter = NULL,
                               subset_from_merge = FALSE,
                               augmented = TRUE,
+                              apply_curated_blacklist = TRUE,
                               engine = 'fread_maf',
                               these_sample_ids,
                               this_seq_type){
@@ -322,6 +324,18 @@ get_ssm_by_samples = function(these_samples_metadata,
     # if/else if chain without assigning maf_df_merge at all, only failing
     # later at return() with a confusing "object not found" error.
     stop(glue::glue("flavour must be one of \"clustered\", \"sage\", or \"legacy\"; got \"{flavour}\"."))
+  }
+
+  # Apply curated blacklist if requested (default)
+  if(apply_curated_blacklist){
+    maf_df_merge = annotate_ssm_blacklist(
+      mutations_df = maf_df_merge, 
+      this_seq_type = unique(these_samples_metadata$seq_type), 
+      genome_build = projection, 
+      use_curated_blacklist = TRUE, 
+      verbose = TRUE
+    ) %>% 
+      select(-blacklist_count)
   }
 
     return(maf_df_merge)

--- a/man/GAMBLR.results-package.Rd
+++ b/man/GAMBLR.results-package.Rd
@@ -13,6 +13,7 @@ This package is part of the Genomic Analysis of Mature B-cell Lymphomas (GAMBL) 
 
 Authors:
 \itemize{
+  \item Kostiantyn Dreval \email{kdreval@sfu.ca} (\href{https://orcid.org/0000-0002-6214-2843}{ORCID})
   \item Ryan Morin \email{rdmorin@sfu.ca} (\href{https://orcid.org/0000-0003-2932-7800}{ORCID})
   \item Vladimir Souza \email{vsouza@bcgsc.ca}
 }

--- a/man/get_all_coding_ssm.Rd
+++ b/man/get_all_coding_ssm.Rd
@@ -4,7 +4,12 @@
 \alias{get_all_coding_ssm}
 \title{Get all Coding SSMs}
 \usage{
-get_all_coding_ssm(these_samples_metadata = NULL, include_silent = FALSE, ...)
+get_all_coding_ssm(
+  these_samples_metadata = NULL,
+  include_silent = FALSE,
+  apply_curated_blacklist = TRUE,
+  ...
+)
 }
 \arguments{
 \item{these_samples_metadata}{Supply a metadata table containing the
@@ -12,6 +17,8 @@ sample/seq_type combinations you want.}
 
 \item{include_silent}{If set to TRUE, silent/synonymous mutations in the
 coding regions will also be returned. Default is FALSE.}
+
+\item{apply_curated_blacklist}{Filter variants that appear in the curated blacklist as specified under config::get("resources")$curated_blacklist. Default: TRUE.}
 
 \item{...}{Additional arguments passed to get_coding_ssm}
 }

--- a/man/get_cnv_and_ssm_status.Rd
+++ b/man/get_cnv_and_ssm_status.Rd
@@ -17,6 +17,7 @@ get_cnv_and_ssm_status(
   adjust_for_ploidy = TRUE,
   include_silent = FALSE,
   binary = TRUE,
+  apply_curated_blacklist = TRUE,
   this_seq_type
 )
 }
@@ -63,6 +64,8 @@ mutations to also be considered}
 
 \item{binary}{Set to FALSE and combine with only_cnv = "all"
 to obtain the actual values (absolute CN) instead of binary status}
+
+\item{apply_curated_blacklist}{Filter variants that appear in the curated blacklist as specified under config::get("resources")$curated_blacklist. Default: TRUE.}
 
 \item{this_seq_type}{Deprecated}
 }

--- a/man/get_coding_ssm.Rd
+++ b/man/get_coding_ssm.Rd
@@ -22,6 +22,7 @@ get_coding_ssm(
   limit_pathology,
   limit_samples,
   from_flatfile,
+  apply_curated_blacklist = TRUE,
   these_sample_ids
 )
 }
@@ -73,6 +74,8 @@ internally called helpers).}
 \item{limit_samples}{Deprecated. Use these_samples_metadata instead.}
 
 \item{from_flatfile}{Deprecated. Ignored}
+
+\item{apply_curated_blacklist}{Filter variants that appear in the curated blacklist as specified under config::get("resources")$curated_blacklist. Default: TRUE.}
 
 \item{these_sample_ids}{Deprecated. Use these_samples_metadata instead.}
 }

--- a/man/get_coding_ssm_status.Rd
+++ b/man/get_coding_ssm_status.Rd
@@ -20,6 +20,7 @@ get_coding_ssm_status(
   genome_build,
   include_silent = FALSE,
   include_silent_genes,
+  apply_curated_blacklist = TRUE,
   suffix,
   this_seq_type
 )
@@ -78,6 +79,8 @@ mutations into coding mutations. Default is FALSE.}
 \item{include_silent_genes}{Optionally, provide a list of genes for which the
 Silent variants to be considered. If provided, the Silent variants for
 these genes will be included regardless of the include_silent argument.}
+
+\item{apply_curated_blacklist}{Filter variants that appear in the curated blacklist as specified under config::get("resources")$curated_blacklist. Default: TRUE.}
 
 \item{suffix}{Optionally provide a character that will be appended to the end of each name}
 

--- a/man/get_ssm_by_genes.Rd
+++ b/man/get_ssm_by_genes.Rd
@@ -11,6 +11,7 @@ get_ssm_by_genes(
   ashm_regions,
   drop_silent_outside_ashm_regions = FALSE,
   expand_by = 10000,
+  apply_curated_blacklist = TRUE,
   verbose = FALSE
 )
 }
@@ -33,6 +34,8 @@ this, real gene-attributed mutations just outside gene_to_region()'s exact
 span (promoter/UTR/annotation-source discrepancies, e.g. a long first
 intron) are never fetched in the first place, and the Hugo_Symbol filter
 below can't recover rows that were never pulled.}
+
+\item{apply_curated_blacklist}{Filter variants that appear in the curated blacklist as specified under config::get("resources")$curated_blacklist. Default: TRUE.}
 }
 \value{
 A data frame containing all the MAF data columns (one row per mutation).

--- a/man/get_ssm_by_regions.Rd
+++ b/man/get_ssm_by_regions.Rd
@@ -16,6 +16,7 @@ get_ssm_by_regions(
   augmented = TRUE,
   projection = "grch37",
   min_read_support = 3,
+  apply_curated_blacklist = TRUE,
   verbose = FALSE,
   these_sample_ids,
   this_seq_type
@@ -60,6 +61,8 @@ Provide to \code{maf_data} the results of \code{get_ssm_by_samples} if those are
 
 \item{min_read_support}{Only returns variants with at least this many reads in t_alt_count
 (for cleaning up augmented MAFs). Default: 3.}
+
+\item{apply_curated_blacklist}{Filter variants that appear in the curated blacklist as specified under config::get("resources")$curated_blacklist. Default: TRUE.}
 
 \item{verbose}{Boolean parameter set to FALSE per default.}
 

--- a/man/get_ssm_by_samples.Rd
+++ b/man/get_ssm_by_samples.Rd
@@ -16,6 +16,7 @@ get_ssm_by_samples(
   variant_classification_filter = NULL,
   subset_from_merge = FALSE,
   augmented = TRUE,
+  apply_curated_blacklist = TRUE,
   engine = "fread_maf",
   these_sample_ids,
   this_seq_type
@@ -64,6 +65,8 @@ the specified this_seq_type.}
 
 \item{augmented}{default: TRUE. Set to FALSE if you instead want
 the original MAF from each sample for multi-sample patients instead.}
+
+\item{apply_curated_blacklist}{Filter variants that appear in the curated blacklist as specified under config::get("resources")$curated_blacklist. Default: TRUE.}
 
 \item{engine}{Specify one of readr or fread_maf (default) to
 change how the large files are loaded prior to subsetting.

--- a/tools/logExampleOutputs.R
+++ b/tools/logExampleOutputs.R
@@ -1,31 +1,17 @@
-library(optparse)
+#! /usr/bin/env Rscript
+# Usage: Rscript /path/to/GAMBLR.results/tools/logExampleOutputs.R
+# If using renv, launch from your project root directory where renv.lock is located
+# Do NOT run interactively
 
-option_list = list(
-	make_option(c("-e", "--renv"), type="logical", default=FALSE, action="store_true",
-		help="Flag to specify whether to use renv or not. [default %default]", metavar="character"),
-	make_option(c("-p", "--path"), type="character", default=NULL, action="store",
-		help="Full path to the directory with the renv files.", metavar="character")
-)
+args <- commandArgs(trailingOnly = FALSE)
+script_path <- sub("--file=", "", args[grep("--file=", args)])
+script_path <- normalizePath(script_path)
 
-opt_parser <- OptionParser(option_list=option_list)
-opt <- parse_args(opt_parser)
-
-current_path <- getwd()
-
-use_renv <- opt$renv
-if(use_renv){
-	if(is.null(opt$path)){
-		stop("Pleaser provide the full path to the directory with the renv files.")
-	}else if(!dir.exists(opt$path)){
-		stop(paste("Directory,", opt$path, "does not exist."))
-	}else{
-		cat("Using renv\n")
-		Sys.setenv(RENV_PROJECT = opt$path)
-		setwd(opt$path)
-		renv::load()
-		setwd(current_path)
-	}
+if(length(script_path) != 1){
+	stop("script_path cannot be determined. Use Rscript /path/to/GAMBLR.results/tools/logExampleOutputs.R. Do not run interactively.")
 }
+
+setwd(dirname(dirname(script_path)))
 
 log_file = "GAMBLR_examples_output.log"
 options(width=2000)


### PR DESCRIPTION
## Describe your changes
We have long had a custom blacklist of artifacts from the Schmitz cohort in GAMBL, but there was no consistent way of dropping these from the output of any get_ssm functions. This PR applies the curated blacklist by default to the output of all get_ssm functions, with an option to toggle this behavior off. This is accompanied by changes in [GAMBL](https://github.com/morinlab/gambl/pull/424]) that allow us to expand the curated blacklist over time, and the GAMBLR config.yml to update the path to the curated blacklist. 

## Indicate which issue(s) this addresses, if applicable
N/A but see [this discussion on Slack](https://morinlabsfu.slack.com/archives/CUCMSL2N8/p1785533361584089). 

## Checklist before requesting a review
- [x] I tested the new function/functionality in a fresh workspace
- [ ] I added at least one working example that demonstrates the new functionality (*if applicable*)
- [x] The test script tools/logExampleOutputs.R ran to completion
- [x] I included the file `GAMBLR_examples_output.log` in my pull request and confirm the changes to this file are expected
